### PR TITLE
Add CuTeDSL Blackwell tutorial GEMM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ bench = [
 cuda = [
     "jax[cuda12]>=0.8.0",
     "nvidia-cudnn-cu12>=9.0.0",
+    "nvidia-cutlass-dsl>=4.4.0",
 ]
 
 tpu = [

--- a/tokamax/_src/autotuning/api.py
+++ b/tokamax/_src/autotuning/api.py
@@ -31,6 +31,8 @@ from tokamax._src.autotuning import cache as cache_lib
 from tokamax._src.ops import op as op_lib
 from tokamax._src.ops.attention import api as attention_api
 from tokamax._src.ops.attention import base as attention_base
+from tokamax._src.ops.matmul import api as matmul_api
+from tokamax._src.ops.matmul import base as matmul_base
 from tokamax._src.ops.gated_linear_unit import api as glu_api
 from tokamax._src.ops.gated_linear_unit import base as glu_base
 from tokamax._src.ops.normalization import api as normalization_api
@@ -217,6 +219,7 @@ _API_IMPLEMENTATIONS: Final[
     Mapping[type[op_lib.Op], Mapping[str, Callable[..., Any]]]
 ] = immutabledict.immutabledict({
     normalization_base.Normalization: normalization_api.IMPLEMENTATIONS,
+    matmul_base.Matmul: matmul_api.IMPLEMENTATIONS,
     glu_base.GatedLinearUnit: glu_api.IMPLEMENTATIONS,
     ragged_dot_base.RaggedDot: ragged_dot_api.IMPLEMENTATIONS,
     attention_base.DotProductAttention: attention_api.IMPLEMENTATIONS,

--- a/tokamax/_src/hlo_utils.py
+++ b/tokamax/_src/hlo_utils.py
@@ -32,6 +32,7 @@ from tokamax._src.ops import op as op_lib
 
 _PALLAS_TRITON_KEY: Final[str] = '__gpu$xla.gpu.triton'
 _MOSAIC_GPU_KEY: Final[str] = 'mosaic_gpu_v2'
+_CUTE_DSL_KEY: Final[str] = 'CuteDSLRT_NvJaxCutlassCall'
 _MOSAIC_TPU_KEY: Final[str] = 'tpu_custom_call'
 _TRITON_KEY: Final[str] = 'triton_kernel_call'
 
@@ -90,6 +91,11 @@ class MosaicTpuKernelInfo(KernelInfoBase):
 @dataclasses.dataclass(frozen=True, slots=True)
 class MosaicGpuKernelInfo(KernelInfoBase):
   """Mosaic GPU kernel information."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CuteDslKernelInfo(KernelInfoBase):
+  """CuTe DSL kernel information."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -221,6 +227,7 @@ _KERNEL_GETTER: Final[
     ]
 ] = immutabledict.immutabledict({
     _MOSAIC_GPU_KEY: _kernel_info_getter(MosaicGpuKernelInfo),
+    _CUTE_DSL_KEY: _kernel_info_getter(CuteDslKernelInfo),
     _MOSAIC_TPU_KEY: _kernel_info_getter(MosaicTpuKernelInfo),
     _PALLAS_TRITON_KEY: _get_pallas_kernel_info,
 })

--- a/tokamax/_src/ops/matmul/api.py
+++ b/tokamax/_src/ops/matmul/api.py
@@ -1,0 +1,85 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from collections.abc import Callable, Sequence
+from typing import Any, Final, Literal, TypeAlias
+
+import immutabledict
+import jax
+import jaxtyping
+from jaxtyping import Array, Float  # pylint: disable=g-multiple-import,g-importing-member
+from tokamax._src.ops.matmul import base
+
+
+Implementation: TypeAlias = Literal["cute_dsl", "xla"]
+
+IMPLEMENTATIONS = dict(xla=base.Matmul())
+_DEFAULT_IMPLEMENTATION = ("xla",)
+
+try:
+  from tokamax._src.ops.matmul import cute_dsl  # pylint: disable=g-import-not-at-top  # pytype: disable=import-error
+
+  IMPLEMENTATIONS["cute_dsl"] = cute_dsl.CuteDslMatmul()
+  _DEFAULT_IMPLEMENTATION = ("cute_dsl",) + _DEFAULT_IMPLEMENTATION
+except ImportError:
+  pass
+
+
+IMPLEMENTATIONS: Final[immutabledict.immutabledict[str, Callable[..., Any]]] = (
+    immutabledict.immutabledict(IMPLEMENTATIONS)
+)
+
+
+@jaxtyping.jaxtyped
+def matmul(
+    a: Float[Array, "M K"],
+    b: Float[Array, "K N"],
+    precision: jax.lax.PrecisionLike = None,
+    preferred_element_type: jax.typing.DTypeLike | None = None,
+    *,
+    implementation: (
+        Implementation
+        | Sequence[Implementation | Callable[..., jax.Array]]
+        | None
+    ) = None,
+) -> Float[Array, "M N"]:  # pylint: disable=g-doc-args
+  if implementation is None:
+    implementation = _DEFAULT_IMPLEMENTATION
+
+  if not isinstance(implementation, (tuple, list)):
+    implementation = (implementation,)
+  elif not implementation:
+    raise ValueError("`implementation` must not be an empty sequence.")
+
+  errors = []
+  for impl in implementation:
+    if isinstance(impl, str):
+      if impl not in IMPLEMENTATIONS:
+        raise ValueError(f"Unknown implementation: {impl}")
+
+      impl = IMPLEMENTATIONS[impl]
+
+    try:
+      return impl(
+          a,
+          b,
+          precision=precision,
+          preferred_element_type=preferred_element_type,
+      )
+    except NotImplementedError as e:
+      if len(implementation) == 1:
+        raise
+      errors.append(e)
+
+  raise ExceptionGroup("all implementations failed", errors)

--- a/tokamax/_src/ops/matmul/api_test.py
+++ b/tokamax/_src/ops/matmul/api_test.py
@@ -1,0 +1,69 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import functools
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from tokamax._src import gpu_utils
+from tokamax._src.autotuning.api import autotune
+from tokamax._src.ops.matmul import api
+from tokamax._src.ops.matmul import test_base
+
+
+class MatmulXlaTest(test_base.MatmulTestBase):
+
+  def __init__(self, *args, implementation=None):
+    matmul_fn = functools.partial(api.matmul, implementation="xla")
+    super().__init__(*args, matmul_fn=matmul_fn)
+
+  def setUp(self):
+    # Strange numerical issues on TPU.
+    if jax.default_backend() == "tpu":
+      self.skipTest("Test disabled on TPU.")
+    super().setUp()
+
+
+class MatmulCuteDslTest(test_base.MatmulTestBase):
+
+  def __init__(self, *args, implementation=None):
+    matmul_fn = functools.partial(api.matmul, implementation="cute_dsl")
+    super().__init__(*args, matmul_fn=matmul_fn)
+
+  def setUp(self):
+    if not (jax.default_backend() == "gpu" and gpu_utils.is_sm100()):
+      self.skipTest("Only SM100 GPU is supported.")
+    super().setUp()
+
+
+class MatmulAutotuneTest(parameterized.TestCase):
+  def test_autotune(self):
+    dtype = jnp.float16
+    key0, key1 = jr.split(jr.key(0), 2)
+    m, n, k = 2048, 2048, 2048
+    a = jr.normal(key0, shape=(m, k), dtype=dtype)
+    b = jr.normal(key1, shape=(k, n), dtype=dtype)
+    autotune_result = autotune(api.matmul, a, b)
+    self.assertNotEmpty(autotune_result.data)
+
+  def setUp(self):
+    if not (jax.default_backend() == "gpu" and gpu_utils.is_sm100()):
+      self.skipTest("Only SM100 GPU is supported.")
+    super().setUp()
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tokamax/_src/ops/matmul/base.py
+++ b/tokamax/_src/ops/matmul/base.py
@@ -1,0 +1,87 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import dataclasses
+from typing import Any, TypeVar
+
+import jax
+import jax.numpy as jnp
+import jaxtyping
+from jaxtyping import Array, Float  # pylint: disable=g-multiple-import,g-importing-member
+from tokamax._src import precision as precision_lib
+from tokamax._src.ops import op
+from typing_extensions import override
+
+
+_Config = TypeVar("_Config")
+_Key = TypeVar("_Key")
+Residuals = type(None)
+CanonicalPrecision = precision_lib.CanonicalPrecision
+
+DIMENSION_NUMBERS = jax.lax.DotDimensionNumbers((((1,), (0,)), ((), ())))
+
+
+@dataclasses.dataclass(frozen=True)
+class Matmul(op.Op[Any, jax.Array, Residuals, _Config, _Key]):
+
+  @override
+  def bind(
+      self,
+      a: Float[Array, "M K"],
+      b: Float[Array, "K N"],
+      *,
+      precision: jax.lax.PrecisionLike = None,
+      preferred_element_type: jax.typing.DTypeLike | None = None,
+      return_residuals: bool = False,
+  ) -> op.BoundArguments:
+    # check that reduction dimensions sizes match
+    (((lhs_contracting_dim,), (rhs_contracting_dim,)), _) = DIMENSION_NUMBERS
+    if a.shape[lhs_contracting_dim] != b.shape[rhs_contracting_dim]:
+      raise ValueError(
+          f"The reduction dimension {lhs_contracting_dim} of a={jax.typeof()}"
+          f" equal to {a.shape[lhs_contracting_dim]} does not match the"
+          f" reduction dimension {rhs_contracting_dim} of b={jax.typeof(b)}"
+          f" equal to {b.shape[rhs_contracting_dim]} for assumed"
+          f" dimension_numbers={DIMENSION_NUMBERS}."
+      )
+    if preferred_element_type is not None:
+      preferred_element_type = jnp.dtype(preferred_element_type)
+    return super().bind(
+        a,
+        b,
+        precision=precision_lib.canonicalize_precision(precision),
+        preferred_element_type=preferred_element_type,
+        return_residuals=return_residuals,
+    )
+
+  @jaxtyping.jaxtyped
+  @override
+  def _fwd(
+      self,
+      a: Float[Array, "M K"],
+      b: Float[Array, "K N"],
+      *,
+      precision: CanonicalPrecision,
+      preferred_element_type: jnp.dtype | None,
+      return_residuals: bool,
+      config: _Config,
+  ) -> tuple[jax.Array, None]:
+    del config  # Unused.
+
+    return jnp.matmul(
+        a,
+        b,
+        precision=precision,
+        preferred_element_type=preferred_element_type,
+    ), None

--- a/tokamax/_src/ops/matmul/cute_dsl.py
+++ b/tokamax/_src/ops/matmul/cute_dsl.py
@@ -1,0 +1,92 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+from tokamax._src import gpu_utils
+from tokamax._src import precision as precision_lib
+from tokamax._src.ops import op
+from tokamax._src.ops.matmul import base
+import tokamax._src.ops.matmul.cute_dsl_common as common
+import tokamax._src.ops.matmul.cute_dsl_kernel_sm100 as sm100
+from typing_extensions import override
+
+Config = common.Config
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class CuteDslMatmul(base.Matmul[Config, None]):
+
+  @override
+  def _fwd(
+      self,
+      a: jax.Array,
+      b: jax.Array,
+      *,
+      precision: base.CanonicalPrecision,
+      preferred_element_type: jnp.dtype | None,
+      return_residuals: bool,
+      config: Config,
+  ) -> tuple[jax.Array, base.Residuals]:
+
+    if not gpu_utils.is_sm100():
+      raise NotImplementedError("Unsupported GPU architecture.")
+    if not precision_lib.is_default(a.dtype, b.dtype, precision):
+      raise NotImplementedError(f"{precision=} not supported.")
+    fn = sm100.matmul_kernel
+    if preferred_element_type is None:
+      preferred_element_type = jnp.promote_types(a.dtype, b.dtype)
+
+    matmul_out = fn(
+        a,
+        b,
+        preferred_element_type,
+        config,
+    )
+    return matmul_out, None
+
+  @override
+  def _get_heuristics_config(self, ba: op.BoundArguments) -> Config:
+    if gpu_utils.is_sm100():
+      return Config(
+          num_ab_stages=4,
+          num_acc_stages=2,
+          block_n=256,
+          block_k=64,
+      )
+    else:
+      raise NotImplementedError("Unsupported GPU architecture.")
+
+  @override
+  def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[Config]:
+    configs = set()
+    for num_ab_stages in (3, 4):
+      for num_acc_stages in range(1, 2+1):
+        for block_n in (128, 256):
+          for block_k in (16, 32, 64, 128):
+            configs.add(
+              Config(
+                num_ab_stages=num_ab_stages,
+                num_acc_stages=num_acc_stages,
+                block_n=block_n,
+                block_k=block_k,
+              )
+            )
+    return configs
+
+  @override
+  def supported_on(self, device: jax.Device) -> bool:
+    return gpu_utils.is_sm100(device)

--- a/tokamax/_src/ops/matmul/cute_dsl_common.py
+++ b/tokamax/_src/ops/matmul/cute_dsl_common.py
@@ -1,0 +1,23 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import pydantic
+
+
+@pydantic.dataclasses.dataclass(frozen=True, slots=True)
+class Config:
+  num_ab_stages: pydantic.conint(ge=3)
+  num_acc_stages: pydantic.PositiveInt
+  block_n: pydantic.conint(multiple_of=8, ge=8, le=256)
+  block_k: pydantic.conint(multiple_of=16, ge=16)

--- a/tokamax/_src/ops/matmul/cute_dsl_kernel_sm100.py
+++ b/tokamax/_src/ops/matmul/cute_dsl_kernel_sm100.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float  # pylint: disable=g-multiple-import,g-importing-member
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils
+
+from cutlass.jax import cutlass_call, jax_to_cutlass_dtype
+from tokamax._src import jaxtyping
+from tokamax._src.ops.matmul import cute_dsl_common as common
+
+
+@jaxtyping.jaxtyped
+def matmul_kernel(
+    a: Float[Array, "M K"],
+    b: Float[Array, "K N"],
+    out_dtype: jnp.dtype,
+    config: common.Config,
+) -> Float[Array, "M N"]:
+
+  m, k_a = a.shape
+  k_b, n = b.shape
+
+  if (a.dtype, b.dtype, out_dtype) != 3 * (jnp.float16,):
+    raise ValueError(
+        "Only float16 x float16 -> float16 is supported, got:"
+        f" {a.dtype=} {b.dtype=} {out_dtype=}."
+    )
+
+  io_dtype = jax_to_cutlass_dtype(jnp.float16)
+  acc_dtype = jax_to_cutlass_dtype(jnp.float32)
+  mma_inst_shape_mnk = (128, config.block_n, 16)
+  mma_tiler_mnk = (128, config.block_n, config.block_k)
+  threads_per_cta = 128
+
+  # Pipeline stage configuration
+  ab_stages = config.num_ab_stages
+  acc_stages = config.num_acc_stages
+
+
+  @cute.struct
+  class SharedStorage:
+    ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, ab_stages * 2]
+    acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, acc_stages * 2]
+    tmem_holding_buf: cutlass.Int32
+
+
+  @cute.kernel
+  def kernel(
+      tiled_mma: cute.TiledMma,
+      tma_atom_a: cute.CopyAtom,
+      mA_mkl: cute.Tensor,
+      tma_atom_b: cute.CopyAtom,
+      mB_nkl: cute.Tensor,
+      mC_mnl: cute.Tensor,
+      a_smem_layout: cute.ComposedLayout,
+      b_smem_layout: cute.ComposedLayout,
+  ):
+    # Current thread/warp/block coordinates
+    tidx, _, _ = cute.arch.thread_idx()
+    warp_idx = cute.arch.warp_idx()
+    warp_idx = cute.arch.make_warp_uniform(warp_idx)
+    bidx, bidy, _ = cute.arch.block_idx()
+    mma_coord_mnk = (bidx, bidy, None)
+
+    #
+    # 1. Prepare args
+    #
+
+    # Allocate SMEM
+    smem = cutlass.utils.SmemAllocator()
+    storage = smem.allocate(SharedStorage)
+    sA = smem.allocate_tensor(
+        element_type=io_dtype,
+        layout=a_smem_layout.outer,
+        byte_alignment=128,
+        swizzle=a_smem_layout.inner,
+    )
+    sB = smem.allocate_tensor(
+        element_type=io_dtype,
+        layout=b_smem_layout.outer,
+        byte_alignment=128,
+        swizzle=b_smem_layout.inner,
+    )
+
+    # Allocate all TMEM columns
+    tmem_alloc_barrier = pipeline.NamedBarrier(
+        barrier_id=1,
+        num_threads=threads_per_cta,
+    )
+    tmem = utils.TmemAllocator(
+        storage.tmem_holding_buf,
+        barrier_for_retrieve=tmem_alloc_barrier,
+    )
+    num_tmem_cols = 512
+    tmem.allocate(num_tmem_cols)
+
+    # Prefetch tma descriptor
+    if warp_idx == 0:
+      cpasync.prefetch_descriptor(tma_atom_a)
+      cpasync.prefetch_descriptor(tma_atom_b)
+
+    # Pipeline configuration
+    num_tma_copy_bytes = cute.size_in_bytes(
+        io_dtype, cute.select(
+            a_smem_layout, mode=[0, 1, 2])) + cute.size_in_bytes(
+                io_dtype, cute.select(b_smem_layout, mode=[0, 1, 2]))
+    ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+        num_stages=ab_stages,
+        producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+        consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+        tx_count=num_tma_copy_bytes,
+        barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+    ).make_participants()
+    acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+        num_stages=acc_stages,
+        producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+        consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread,
+                                                 threads_per_cta),
+        barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+    ).make_participants()
+
+    # Partition tensors for MMA and make fragments
+    # (bM, bK, RestK)
+    gA = cute.local_tile(mA_mkl, mma_tiler_mnk, mma_coord_mnk, proj=(1, None, 1))
+    # (bN, bK, RestK)
+    gB = cute.local_tile(mB_nkl, mma_tiler_mnk, mma_coord_mnk, proj=(None, 1, 1))
+    # (bM, bN)
+    gC = cute.local_tile(mC_mnl, mma_tiler_mnk, mma_coord_mnk, proj=(1, 1, None))
+    thr_mma = tiled_mma.get_slice(0)
+    # (MMA, MMA_M, MMA_K, RestK)
+    tCgA = thr_mma.partition_A(gA)
+    # (MMA, MMA_N, MMA_K, RestK)
+    tCgB = thr_mma.partition_B(gB)
+    # (MMA, MMA_M, MMA_N)
+    tCgC = thr_mma.partition_C(gC)
+    # (MMA, MMA_M, MMA_K, STAGE)
+    tCrA = tiled_mma.make_fragment_A(sA)
+    # (MMA, MMA_N, MMA_K, STAGE)
+    tCrB = tiled_mma.make_fragment_B(sB)
+    # (MMA, MMA_M, MMA_N)
+    acc_shape = tiled_mma.partition_shape_C(mma_tiler_mnk[:2])
+    # (MMA, MMA_M, MMA_N)
+    tCtAcc = tiled_mma.make_fragment_C(acc_shape)
+    # Partition tensors for TMA; This requires the tensors partitioned for MMA
+    tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+        tma_atom_a,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sA, 0, 3),
+        cute.group_modes(tCgA, 0, 3),
+    )
+    tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+        tma_atom_b,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sB, 0, 3),
+        cute.group_modes(tCgB, 0, 3),
+    )
+
+    # CTA-wide sync before retrieving the pointer to the start of the allocated TMEM
+    # Only warp 0 does the allocation so we need to sync before retrieving the TMEM start address
+    tmem.wait_for_alloc()
+    tmem_ptr = tmem.retrieve_ptr(acc_dtype)
+    # Swap the pointer in tCtAcc
+    tCtAcc = cute.make_tensor(tmem_ptr, tCtAcc.layout)
+
+    subtile_cnt = 4
+    # (EpiTile)
+    epi_tiler = ((
+        cute.size(tCtAcc, mode=[0, 0]),
+        cute.size(tCtAcc, mode=[0, 1]) // subtile_cnt,
+    ),)
+    # (EpiTile, NumTiles)
+    tCtAcc_epi = cute.zipped_divide(tCtAcc, epi_tiler)
+    # (EpiTile, NumTiles)
+    gC_epi = cute.zipped_divide(tCgC, epi_tiler)
+
+    # Every thread loads 32x128 bits
+    tmem_atom = cute.make_copy_atom(
+        tcgen05.Ld32x32bOp(tcgen05.Repetition.x64),
+        cutlass.Float32,
+    )
+    tmem_tiled_copy = tcgen05.make_tmem_copy(tmem_atom, tCtAcc_epi[None, 0])
+    tmem_thr_copy = tmem_tiled_copy.get_slice(tidx)
+
+    # (TmemCpy,NumTmemCpy,NumTiles)
+    tDtC = tmem_thr_copy.partition_S(tCtAcc_epi)
+    # (TmemCpy,NumTmemCpy,NumTiles)
+    tDgC = tmem_thr_copy.partition_D(gC_epi)
+
+    # (TmemCpy,NumTmemCpy)
+    tCrAcc = cute.make_rmem_tensor(tDgC[None, None, 0].shape, acc_dtype)
+    # (TmemCpy,NumTmemCpy)
+    tCrC = cute.make_rmem_tensor(tDgC[None, None, 0].shape, io_dtype)
+
+    #
+    # 2. Main loop
+    #
+    num_k_tiles = cute.size(gA, mode=[2])
+    if warp_idx == 0:
+      # Wait for a empty accumulator buffer
+      acc_empty = acc_producer.acquire_and_advance()
+      for k_tile_idx in cutlass.range(num_k_tiles, prefetch_stages=ab_stages - 2):
+        # Issue TMA loads
+        ab_empty = ab_producer.acquire_and_advance()
+        cute.copy(
+            tma_atom_a,
+            tAgA[(None, ab_empty.count)],
+            tAsA[(None, ab_empty.index)],
+            tma_bar_ptr=ab_empty.barrier,
+        )
+        cute.copy(
+            tma_atom_b,
+            tBgB[(None, ab_empty.count)],
+            tBsB[(None, ab_empty.index)],
+            tma_bar_ptr=ab_empty.barrier,
+        )
+
+        # Execute one K-block worth of MMA instructions
+        ab_full = ab_consumer.wait_and_advance()
+        num_k_blocks = cute.size(tCrA, mode=[2])
+        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+          k_block_coord = (None, None, k_block_idx, ab_full.index)
+          cute.gemm(
+              tiled_mma,
+              tCtAcc,
+              tCrA[k_block_coord],
+              tCrB[k_block_coord],
+              tCtAcc,
+          )
+          tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+        # Signal that the A/B buffers have been consumed and are ready for the next load
+        ab_full.release()
+
+      # Signal that the accumulator is fully computed
+      acc_empty.commit()
+
+    #
+    # 3. Epilogue
+    #
+
+    # Release TMEM allocation lock
+    tmem.relinquish_alloc_permit()
+
+    # Wait for the accumulator buffer to be full
+    acc_full = acc_consumer.wait_and_advance()
+
+    # TMEM -> RMEM -> GEMM
+    # Sub-tiling for better instruction-level parallelism
+    for i in cutlass.range(cute.size(tDtC, mode=[2])):
+      cute.copy(tmem_tiled_copy, tDtC[None, None, i], tCrAcc)
+      tCrC.store(tCrAcc.load().to(io_dtype))
+      cute.autovec_copy(tCrC, tDgC[None, None, i])
+    acc_full.release()
+
+    # Deallocate TMEM
+    pipeline.sync(barrier_id=1)
+    tmem.free(tmem_ptr)
+
+
+  @cute.jit
+  def host_function(
+      stream,
+      a: cute.Tensor,
+      b: cute.Tensor,
+      c: cute.Tensor,
+  ):
+    # Construct tiled MMA
+    op = tcgen05.MmaF16BF16Op(
+        io_dtype,
+        acc_dtype,
+        mma_inst_shape_mnk,
+        tcgen05.CtaGroup.ONE,
+        tcgen05.OperandSource.SMEM,
+        tcgen05.OperandMajorMode.K,
+        tcgen05.OperandMajorMode.MN,
+    )
+    tiled_mma = cute.make_tiled_mma(op)
+
+    # Construct SMEM layouts for A and B
+    a_smem_layout = sm100_utils.make_smem_layout_a(
+        tiled_mma,
+        mma_tiler_mnk,
+        a.element_type,
+        ab_stages,
+    )
+    b_smem_layout = sm100_utils.make_smem_layout_b(
+        tiled_mma,
+        mma_tiler_mnk,
+        b.element_type,
+        ab_stages,
+    )
+    a_smem_layout_one_stage = cute.select(a_smem_layout, mode=[0, 1, 2])
+    b_smem_layout_one_stage = cute.select(b_smem_layout, mode=[0, 1, 2])
+
+    # Construct TMA load atoms
+    op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
+    a_tma_atom, a_tma_tensor = cute.nvgpu.make_tiled_tma_atom_A(
+        op,
+        a,
+        a_smem_layout_one_stage,
+        mma_tiler_mnk,
+        tiled_mma,
+    )
+    b_tma_atom, b_tma_tensor = cute.nvgpu.make_tiled_tma_atom_B(
+        op,
+        b,
+        b_smem_layout_one_stage,
+        mma_tiler_mnk,
+        tiled_mma,
+    )
+
+    # Pretty prints kernel attributes useful for debugging
+    # print(f"a            = {cute.pretty_str(a)}")
+    # print(f"b            = {cute.pretty_str(b)}")
+    # print(f"c            = {cute.pretty_str(c)}")
+    # print(f"tiled_mma    = {cute.pretty_str(tiled_mma)}")
+    # print(f"a_tma_atom   = {cute.pretty_str(a_tma_atom)}")
+    # print(f"b_tma_atom   = {cute.pretty_str(b_tma_atom)}")
+    # print(f"a_tma_tensor = {cute.pretty_str(a_tma_tensor)}")
+    # print(f"b_tma_tensor = {cute.pretty_str(b_tma_tensor)}")
+
+    # Launch the kernel
+    grid_shape = cute.ceil_div((*c.layout.shape, 1), mma_tiler_mnk[:2])
+    kernel(
+        tiled_mma,
+        a_tma_atom,
+        a_tma_tensor,
+        b_tma_atom,
+        b_tma_tensor,
+        c,
+        a_smem_layout,
+        b_smem_layout,
+    ).launch(
+        stream=stream,
+        grid=grid_shape,
+        block=(threads_per_cta, 1, 1),
+    )
+
+  f = cutlass_call(
+      host_function,
+      input_mode=((0, 1), (1, 0)),
+      output_mode=((0, 1),),
+      output_shape_dtype=jax.ShapeDtypeStruct((m, n), dtype=out_dtype),
+  )
+  return f(a, b)

--- a/tokamax/_src/ops/matmul/test_base.py
+++ b/tokamax/_src/ops/matmul/test_base.py
@@ -1,0 +1,56 @@
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import itertools
+
+from absl.testing import parameterized
+import chex
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from tokamax._src.ops.matmul import base
+
+
+def ref(a, b):
+  """Reference implementation of matmul."""
+
+  return jax.lax.dot(
+      a,
+      b,
+      dimension_numbers=base.DIMENSION_NUMBERS,
+      precision=jax.lax.Precision.HIGHEST,
+  )
+
+
+class MatmulTestBase(parameterized.TestCase):
+
+  def __init__(self, *args, matmul_fn):
+    super().__init__(*args)
+    self._matmul_fn = matmul_fn
+
+  @parameterized.named_parameters(
+    (f"{m=}-{n=}-{k=}", m, n, k)
+    for m, n, k in itertools.product(
+        (1024, 2048),
+        (1024, 2048),
+        (1024, 2048),
+    )
+  )
+  def test_simple(self, m, n, k):
+    dtype = jnp.float16
+    key0, key1 = jr.split(jr.key(0), 2)
+    a = jr.normal(key0, shape=(m, k), dtype=dtype)
+    b = jr.normal(key1, shape=(k, n), dtype=dtype)
+    actual = self._matmul_fn(a, b)
+    chex.assert_trees_all_close(actual, ref(a, b))


### PR DESCRIPTION
This is a tutorial, non-performance-oriented, Blackwell GEMM implemented using CuTeDSL.
Based on this essentially unmodified kernel: https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_0.py.