### PR TITLE
Fix wrong `rhs` gradient for empty groups in Pallas-Triton ragged dot.

### DIFF
--- a/tokamax/_src/ops/ragged_dot/pallas_triton.py
+++ b/tokamax/_src/ops/ragged_dot/pallas_triton.py
@@ -273,7 +273,9 @@ def _ragged_contracting_dim_dot_kernel(
   num_iters = pl.cdiv(jnp.int32(hi - lo), block_k)
   acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
   acc = jax.lax.fori_loop(0, num_iters - 1, body, acc)
-  acc = body(num_iters - 1, acc, mask_k=True)  # Mask final iteration.
+  # Clamp the masked-tail index so empty groups (num_iters == 0) read at i=0
+  # with mask `arange(block_k) < hi - lo == 0` (all False) instead of i=-1.
+  acc = body(jnp.maximum(num_iters - 1, 0), acc, mask_k=True)
   if activation is not None:
     acc = activation(acc)
   out_ref.store(acc.astype(out_ref.dtype))

--- a/tokamax/_src/ops/ragged_dot/test_base.py
+++ b/tokamax/_src/ops/ragged_dot/test_base.py
@@ -188,6 +188,79 @@ class RaggedDotTestBase(parameterized.TestCase):
         count = sum(group_sizes_)
         chex.assert_trees_all_close(actual[:count], expected[:count])
 
+  @parameterized.parameters(
+      # (num_groups, group_sizes_pattern_int)
+      # Mix of empty and non-empty groups, all bits patterns covered by
+      # `test_zero_group_sizes` for forward; here we cover representative
+      # patterns for VJP to keep runtime bounded.
+      # (Bit order is MSB-first via `jnp.unpackbits`.)
+      (8, 0b10101010),  # alternating; empty at groups 1, 3, 5, 7
+      (8, 0b01010101),  # alternating; empty at groups 0, 2, 4, 6
+      (8, 0b11110000),  # empty tail (groups 4-7)
+      (8, 0b00001111),  # empty prefix (groups 0-3)
+      (8, 0b11111110),  # single empty group at the end (group 7)
+      (8, 0b01111111),  # single empty group at the start (group 0)
+      (8, 0b10000001),  # empty groups in the middle (1-6)
+  )
+  def test_vjp_zero_group_sizes(self, num_groups, pattern):
+    """VJP correctness when some groups are empty.
+
+    This exercises the `drhs` ragged-contracting path. For any group `g` with
+    `group_sizes[g] == 0`, `rhs.grad[g]` must be exactly zero (no tokens
+    contributed to it). We also check the full gradient against the reference.
+    """
+    m, k, n = 1024, 128, 256
+    a, b, group_sizes = self._create_inputs(num_groups, m, k, n, jnp.bfloat16)
+    bits = jnp.unpackbits(jnp.uint8(pattern))
+    group_sizes = jnp.where(bits, group_sizes, 0)
+
+    a_ref = a.astype(jnp.float32)
+    b_ref = b.astype(jnp.float32)
+    f = functools.partial(
+        self._dot_fn_f32,
+        group_sizes=group_sizes,
+        precision=jax.lax.DotAlgorithmPreset.BF16_BF16_F32,
+    )
+    f_ref = functools.partial(ref, group_sizes=group_sizes)
+
+    actual_fwd, f_vjp = jax.vjp(f, a, b)
+    expected_fwd, f_ref_vjp = jax.vjp(f_ref, a_ref, b_ref)
+    count = int(jnp.sum(group_sizes))
+    chex.assert_trees_all_close(
+        actual_fwd[:count], expected_fwd[:count], atol=1e-5
+    )
+
+    dout = jax.nn.standardize(expected_fwd)
+    dout = dout.astype(jnp.bfloat16).astype(actual_fwd.dtype)
+    # Zero out the dout for padded rows so they don't contribute spurious
+    # gradient mass through the lhs path.
+    row_idx = jnp.arange(dout.shape[0])
+    dout = jnp.where(row_idx[:, None] < count, dout, 0)
+
+    expected_grads = f_ref_vjp(dout.astype(expected_fwd.dtype))
+    actual_grads = f_vjp(dout)
+
+    da_actual, db_actual = actual_grads
+    da_expected, db_expected = expected_grads
+
+    # Only compare lhs gradient for the populated rows. Padded rows are
+    # implementation-defined.
+    chex.assert_trees_all_close(
+        da_actual[:count], da_expected[:count], atol=0.02, rtol=0.005
+    )
+    chex.assert_trees_all_close(
+        db_actual, db_expected, atol=0.02, rtol=0.005
+    )
+
+    # Hard invariant: empty groups must have exactly-zero rhs gradient.
+    empty_groups = np.flatnonzero(np.asarray(group_sizes) == 0)
+    for g in empty_groups:
+      with self.subTest(f"empty_group_{int(g)}"):
+        np.testing.assert_array_equal(
+            np.asarray(db_actual[int(g)]),
+            np.zeros_like(np.asarray(db_actual[int(g)])),
+        )
+
   @parameterized.product(
       dtype=("int8", "int4"),
       a_tile_shape=(None, (1, 128), (1, 16), (256, 1), (16, 1)),


### PR DESCRIPTION
`_ragged_contracting_dim_dot_kernel` always runs a "final masked iteration"
at `i = num_iters - 1`. For empty groups `num_iters == 0`, so `i = -1`,
`start_k = lo - block_k`, and the boundary mask `arange(block_k) < hi - start_k`
collapses to all-True — junk gets dotted into `drhs[g]`.

JAX's `jax.lax.ragged_dot` returns 0 for empty groups; this silently corrupted
MoE gradients without raising.

## Fix

`pallas_triton.py`, one line:

```diff
-acc = body(num_iters - 1, acc, mask_k=True)
+acc = body(jnp.maximum(num_iters - 1, 0), acc, mask_k=True)
```

For `num_iters >= 1` this is identical. For `num_iters == 0` we read at `i = 0`,
where the existing mask `arange(block_k) < hi - lo == 0` is all-False on its
own. No new branches.

## Test

`test_vjp_zero_group_sizes` in `test_base.py`, parameterized over 7 empty-group
patterns. Asserts (a) full-gradient parity with `jax.lax.ragged_dot` and
(b) `rhs.grad[g]` is exactly zero for every empty `g`.

Pallas-Triton on RTX 6000 Ada: 5/7 fail before, 7/7 pass after. XLA reference
passes 7/7 throughout. Existing forward + VJP tests (32 cases) still pass.

## Other backends

Bug is Pallas-Triton-only.

- Mosaic-GPU SM90: WGMMA-time mask collapses to false on empty groups.
- Mosaic-GPU SM100: raises `NotImplementedError` for the contracting-dim path.
- Mosaic-TPU: `tgmm` schedules an explicit zero-fill tile per empty group via
  `visit_empty_groups=True`.
