### PR TITLE
Enable cuequivariance benchmark to use CUDA kernels on H100.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ test = [
 bench = [
     "google-benchmark>=1.9.0",
     "xprof",
-    "cuequivariance-jax>=0.8.1",
+    "cuequivariance-jax>=0.10.0",
+    "cuequivariance-ops-jax-cu13>=0.10.0",
+    "triton"
 ]
 
 cuda = [

--- a/tokamax/benchmarks/benchmark_registry.pbtxt
+++ b/tokamax/benchmarks/benchmark_registry.pbtxt
@@ -8,20 +8,20 @@ benchmarks {
   workload {
     action: "./ml_actions/benchmarking/actions/workload_executors/python"
     action_inputs { key: "script_path" value: "tokamax/benchmarks/attention.py" }
-    action_inputs { key: "python_version" value: "3.13" }
+    action_inputs { key: "python_version" value: "3.11" }
   }
 
   environment_configs {
     id: "gpu-h100"
     runner_label: "linux-x86-a3-8g-h100-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
   }
 
   environment_configs {
     id: "gpu-b200"
     runner_label: "linux-x86-a4-224-b200-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
   }
 
@@ -57,21 +57,21 @@ benchmarks {
   workload {
     action: "./ml_actions/benchmarking/actions/workload_executors/python"
     action_inputs { key: "script_path" value: "tokamax/benchmarks/triangle_multiplication.py" }
-    action_inputs { key: "python_version" value: "3.13" }
+    action_inputs { key: "python_version" value: "3.11" }
     action_inputs { key: "extras" value: "bench" }
   }
 
   environment_configs {
     id: "gpu-h100"
     runner_label: "linux-x86-a3-8g-h100-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
   }
 
   environment_configs {
     id: "gpu-b200"
     runner_label: "linux-x86-a4-224-b200-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
   }
 
@@ -105,13 +105,13 @@ benchmarks {
   workload {
     action: "./ml_actions/benchmarking/actions/workload_executors/python"
     action_inputs { key: "script_path" value: "tokamax/benchmarks/ragged_dot.py" }
-    action_inputs { key: "python_version" value: "3.13" }
+    action_inputs { key: "python_version" value: "3.11" }
   }
 
   environment_configs {
     id: "gpu-h100"
     runner_label: "linux-x86-a3-8g-h100-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
     # Disable 'xla' as this OOM on GPU.
     workload_action_inputs { key: "runtime_flags_hw" value: "--skip_implementations=xla" }
@@ -120,7 +120,7 @@ benchmarks {
   environment_configs {
     id: "gpu-b200"
     runner_label: "linux-x86-a4-224-b200-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
     # Disable 'xla' as this OOM on GPU.
     # TODO: enable 'mosaic' and None once the bug is fixed.
@@ -159,13 +159,13 @@ benchmarks {
   workload {
     action: "./ml_actions/benchmarking/actions/workload_executors/python"
     action_inputs { key: "script_path" value: "tokamax/benchmarks/linear_softmax_cross_entropy_loss.py" }
-    action_inputs { key: "python_version" value: "3.13" }
+    action_inputs { key: "python_version" value: "3.11" }
   }
 
   environment_configs {
     id: "gpu-h100"
     runner_label: "linux-x86-a3-8g-h100-1gpu"
-    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.0-cudnn9.15@sha256:94b11493f1637114e6ac08752c10c957f341abd2d293f24e2c0458b81c220411"
+    container_image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cuda13.2-cudnn9.15@sha256:98d10696f84ab6b4dff4356c8c654c3f142f002e804a80d22817450ca9574a7d"
     workload_action_inputs { key: "extras_hw" value: "cuda" }
   }
 

--- a/tokamax/benchmarks/triangle_multiplication.py
+++ b/tokamax/benchmarks/triangle_multiplication.py
@@ -28,10 +28,9 @@ from tensorboardX import writer
 import tokamax
 from tokamax._src import numerics
 
-
 try:
   import cuequivariance_jax  # pylint: disable=g-import-not-at-top,import-error # pytype: disable=import-error
-except ImportError:
+except Exception:  # pylint: disable=broad-except
   cuequivariance_jax = None
 
 SummaryWriter = writer.SummaryWriter
@@ -66,6 +65,7 @@ def get_example(n, c=64, h=64, d=64, dtype=jnp.float32) -> Any:
 
 def convert_tokamax_weights_to_cuequivariance(tokamax_weights):
   """Converts Tokamax weights to cuEquivariance format."""
+
   # Tokamax Input Proj: [C, 2, H] -> [2*H, C] for cuEquivariance.
   # Since C=H, we flatten (C, 2, H) -> (C, 2*H) then transpose -> (2*H, C)
   def transform_in(w):
@@ -139,7 +139,7 @@ class TriangleMultiplicationBenchmark(parameterized.TestCase):
           direction=all_inputs['triangle_type'],
           mask=all_inputs['mask'].astype(all_inputs['x'].dtype),
           eps=1e-6,
-          fallback=True,
+          fallback=False,
           **cueq_weights,
       )
       dynamic_args = {


### PR DESCRIPTION
Enable cuequivariance benchmark to use CUDA kernels on H100.

Fixes running on TPU where OS exceptions can be thrown now.
