### PR TITLE
Make Tokamax only parse the args that it defines.

### DIFF
--- a/tokamax/_src/config.py
+++ b/tokamax/_src/config.py
@@ -63,7 +63,12 @@ class _ConfigOption(Generic[_T]):
   @property
   def value(self) -> _T:
     if not flags.FLAGS.is_parsed():
-      flags.FLAGS(sys.argv)
+      # `known_only=True` parses the flags absl actually defines (so any
+      # `--tokamax_*` flags on the command line still take effect) and ignores
+      # the rest instead of raising `UnrecognizedFlagError`. Tokamax is a
+      # library, so `sys.argv` may carry flags owned by the host program
+      # (pytest's `-s`, vLLM's CLI args, etc.) that absl does not recognize.
+      flags.FLAGS(sys.argv, known_only=True)
     return getattr(_STATE, self.flag.name, self.flag.value)
 
 


### PR DESCRIPTION
Problem: When I import Tokamax GMM (ragged_dot) to TPU-inference (https://github.com/vllm-project/tpu-inference/pull/2896), running a test in TPU-inference (`pytest -s -vv  tpu-inference/tests/layers/vllm/test_fp8.py -k test_fused_moe`) would fails with an error from Tokamax: https://gist.github.com/vanbasten23/afd2e7b9b785078f3e3eb933be3a944a.

Root cause: [Here](https://github.com/openxla/tokamax/blob/df4f506d7e6936fae4c5fd29256ccf6f52288965/tokamax/_src/config.py#L66):
```
  @property
  def value(self) -> _T:
    if not flags.FLAGS.is_parsed():
      flags.FLAGS(sys.argv)  # <--- bug
    return getattr(_STATE, self.flag.name, self.flag.value)
```
Under the pytest, the `sys.argv` is ['pytest', '-s', '-vv', ..., '-k', `test_fused_moe`]. Tokamax hands the whole thing to absl, which doesn't know pytest's '-s' flag, hence it raises the `UnrecognizedFlagError: Unknown command line flag 's'` This error not only hit the test, but it also hit any other TPU-inference command (eg vllm CLI).

Fix: Add `know_only=True` to make absl parse only the flags that Tokamax actually defines (eg: --tokamax_autotuning_cache_miss_fallback=error) and leave everthing else unparsed.