### PR TITLE
fix: use PallasTritonFlexAttention instead of PallasTritonGatedLinearUnit in flex_attention API

### DIFF
--- a/tokamax/_src/ops/flex_attention/api.py
+++ b/tokamax/_src/ops/flex_attention/api.py
@@ -25,6 +25,6 @@ IMPLEMENTATIONS: Final[dict[str, base.FlexAttention]] = dict(
 try:
   from tokamax._src.ops.flex_attention import pallas_triton  # pylint: disable=g-import-not-at-top  # pytype: disable=import-error
 
-  IMPLEMENTATIONS['triton'] = pallas_triton.PallasTritonGatedLinearUnit()
+  IMPLEMENTATIONS['triton'] = pallas_triton.PallasTritonFlexAttention()
 except ImportError:
   pass


### PR DESCRIPTION
## Summary

Fix incorrect class instantiation in `flex_attention/api.py`.

The `IMPLEMENTATIONS['triton']` entry was using `pallas_triton.PallasTritonGatedLinearUnit()` (from the `gated_linear_unit` module) instead of `pallas_triton.PallasTritonFlexAttention()`.

## Details

- `PallasTritonGatedLinearUnit` is defined in `gated_linear_unit/pallas_triton.py:106` and extends `base.GatedLinearUnit`
- `PallasTritonFlexAttention` is defined in `flex_attention/pallas_triton.py:438` and extends `base.FlexAttention`
- The type annotation `dict[str, base.FlexAttention]` on line 21 confirms the dictionary expects `FlexAttention` instances

This appears to be a copy-paste error from when the `flex_attention` API was created using the `gated_linear_unit` API as a template.

## Change

```diff
-  IMPLEMENTATIONS['triton'] = pallas_triton.PallasTritonGatedLinearUnit()
+  IMPLEMENTATIONS['triton'] = pallas_triton.PallasTritonFlexAttention()
```
