### PR TITLE
docs: add triangle_multiplication and ragged_dot_general to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ And the following for both GPU and TPU:
 
 *   `tokamax.ragged_dot`
     ([Mixture of Experts](https://arxiv.org/abs/2211.15841)).
+*   `tokamax.ragged_dot_general`
+    (Generalized ragged dot with flexible contracting dimensions).
 
 And the following TPU kernels:
 
 *   `tokamax.linear_softmax_cross_entropy_loss`
     ([Memory Efficient Linear Cross Entropy Loss Kernel](https://arxiv.org/abs/2410.10989v2))
+
+And the following XLA kernels:
+
+*   `tokamax.triangle_multiplication`
+    ([AlphaFold](https://doi.org/10.1038/s41586-021-03819-2) Supplementary
+    Algorithm 11 and 12).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Add `triangle_multiplication` and `ragged_dot_general` to the README's Status section.

Both operations are exported in the public API (`tokamax/__init__.py`) but were not listed in the README.

## Changes

Added two missing operations to the README:

- **`tokamax.triangle_multiplication`** — Implements AlphaFold's Supplementary Algorithm 11 and 12 for triangle multiplicative updates. Currently XLA-only backend.
- **`tokamax.ragged_dot_general`** — Generalized ragged dot with flexible contracting dimensions. Supports GPU and TPU.

## Evidence

Both are exported in [`tokamax/__init__.py`](https://github.com/openxla/tokamax/blob/main/tokamax/__init__.py):

```python
from tokamax._src.ops.ragged_dot.api import ragged_dot_general as ragged_dot_general  # line 36
from tokamax._src.ops.triangle_multiplication.api import triangle_multiplication as triangle_multiplication  # line 39
```
