### PR TITLE
docs: add dedicated documentation for Gated Linear Unit (SwiGLU) and Layer Normalization (RMSNorm)

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -31,5 +31,9 @@ toc:
     path: /tokamax/tokamax_demo
 - title: Op-specific Documentation
   section:
-  - title: Splash Attention
+  - title: Dot Product Attention (Splash Attention)
     path: /tokamax/splash_attention
+  - title: Gated Linear Unit (GLU / SwiGLU)
+    path: /tokamax/gated_linear_unit
+  - title: Layer Normalization (LayerNorm / RMSNorm)
+    path: /tokamax/normalization

--- a/docs/gated_linear_unit.md
+++ b/docs/gated_linear_unit.md
@@ -1,0 +1,109 @@
+# Gated Linear Unit (GLU)
+
+The `gated_linear_unit` function computes a gated linear unit
+([Dauphin et al., 2017](https://arxiv.org/abs/1612.08083)):
+
+```
+output = activation(x @ w_gate) * (x @ w_up)
+```
+
+This is a key building block in modern Transformer feed-forward networks.
+Depending on the choice of activation function, this implements:
+
+| Activation | Name | Reference |
+|---|---|---|
+| `jax.nn.swish` | **SwiGLU** | [Shazeer, 2020](https://arxiv.org/abs/2002.05202) |
+| `jax.nn.gelu` | **GEGLU** | [Shazeer, 2020](https://arxiv.org/abs/2002.05202) |
+| `jax.nn.relu` | **REGLU** | [Shazeer, 2020](https://arxiv.org/abs/2002.05202) |
+| `jax.nn.sigmoid` | **GLU** | [Dauphin et al., 2017](https://arxiv.org/abs/1612.08083) |
+| `None` | Bilinear (no gate activation) | — |
+
+SwiGLU is the most widely used variant, powering models like LLaMA, PaLM,
+Gemini, and Mistral.
+
+## Usage
+
+```python
+import jax
+import jax.numpy as jnp
+import tokamax
+
+# Input: (batch, seq_len, hidden_dim)
+x = jnp.ones((2, 1024, 4096), dtype=jnp.bfloat16)
+
+# Fused weights: (hidden_dim, 2, intermediate_dim)
+weights = jnp.ones((4096, 2, 11008), dtype=jnp.bfloat16)
+
+# SwiGLU (default in LLaMA-style models)
+output = tokamax.gated_linear_unit(x, weights, activation=jax.nn.swish)
+
+# GEGLU
+output = tokamax.gated_linear_unit(x, weights, activation=jax.nn.gelu)
+```
+
+### Unfused Weights
+
+Weights can also be provided as a tuple of two separate arrays:
+
+```python
+w_gate = jnp.ones((4096, 11008), dtype=jnp.bfloat16)
+w_up = jnp.ones((4096, 11008), dtype=jnp.bfloat16)
+
+output = tokamax.gated_linear_unit(x, (w_gate, w_up), activation=jax.nn.swish)
+```
+
+## Implementations
+
+| Implementation | Hardware | Notes |
+|---|---|---|
+| `'xla'` | All platforms | Default fallback; unfused matmuls via XLA |
+| `'mosaic'` | NVIDIA GPU (SM90+) | Fused Mosaic GPU kernel; best performance on H100/B200 |
+| `'triton'` | NVIDIA GPU | Fused Triton kernel |
+
+By default, Tokamax automatically selects the best available implementation.
+To override:
+
+```python
+# Force a specific implementation
+output = tokamax.gated_linear_unit(
+    x, weights,
+    activation=jax.nn.swish,
+    implementation='mosaic',
+)
+
+# Try multiple implementations in order
+output = tokamax.gated_linear_unit(
+    x, weights,
+    activation=jax.nn.swish,
+    implementation=['mosaic', 'triton', 'xla'],
+)
+```
+
+## API Reference
+
+### `tokamax.gated_linear_unit`
+
+```python
+tokamax.gated_linear_unit(
+    x: Float[Array, '*B M K'],
+    weights: FusedWeights | UnfusedWeights,
+    *,
+    activation: Callable[[Array], Array] | None = None,
+    precision: jax.lax.PrecisionLike = None,
+    implementation: Implementation | Sequence[Implementation] | None = None,
+) -> Float[Array, '*B M N']
+```
+
+**Arguments:**
+
+- **`x`**: Input array of shape `(*B, M, K)`.
+- **`weights`**: Either a fused array of shape `(K, 2, N)` or a tuple of two
+  unfused arrays, each of shape `(K, N)`.
+- **`activation`**: Activation function applied to the gate branch. Common
+  choices: `jax.nn.swish`, `jax.nn.gelu`, `jax.nn.relu`, `jax.nn.sigmoid`.
+  If `None`, no activation is applied (bilinear).
+- **`precision`**: Matrix multiplication precision. `None` uses the backend
+  default, or pass `jax.lax.Precision` / `jax.lax.DotAlgorithmPreset`.
+- **`implementation`**: Which backend to use. `None` auto-selects.
+
+**Returns:** Output array of shape `(*B, M, N)`.

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -1,0 +1,104 @@
+# Layer Normalization
+
+The `layer_norm` function implements both LayerNorm
+([Ba et al., 2016](https://arxiv.org/abs/1607.06450)) and RMSNorm
+([Zhang & Sennrich, 2019](https://arxiv.org/abs/1910.07467)).
+
+These are essential normalization layers used in virtually all modern
+Transformer architectures. RMSNorm (enabled via `subtract_mean=False`) is
+the default choice in LLaMA, Gemini, Mistral, and DeepSeek models due to its
+lower computational cost compared to full LayerNorm.
+
+## Usage
+
+```python
+import jax.numpy as jnp
+import tokamax
+
+# Input: (batch, seq_len, hidden_dim)
+x = jnp.ones((2, 1024, 4096), dtype=jnp.bfloat16)
+
+# Scale and offset parameters
+scale = jnp.ones((4096,), dtype=jnp.float32)
+offset = jnp.zeros((4096,), dtype=jnp.float32)
+
+# Standard LayerNorm
+output = tokamax.layer_norm(x, scale, offset)
+
+# RMSNorm (no mean subtraction — used in LLaMA, Gemini, etc.)
+output = tokamax.layer_norm(x, scale, offset=None, subtract_mean=False)
+```
+
+### Numeric Precision
+
+FP16 and BF16 inputs are automatically upcast to FP32 for all internal
+computations (mean, variance, normalization). The result is then downcast back
+to the input dtype. This ensures numeric stability without requiring manual
+dtype management.
+
+## Implementations
+
+| Implementation | Hardware | Notes |
+|---|---|---|
+| `'xla'` | All platforms | Default fallback; uses `jax.nn.standardize` |
+| `'triton'` | NVIDIA GPU | Fused Triton kernel; best GPU performance |
+
+By default, Tokamax automatically selects the best available implementation.
+
+```python
+# Force Triton implementation (GPU only)
+output = tokamax.layer_norm(x, scale, offset, implementation='triton')
+
+# Try Triton first, fall back to XLA
+output = tokamax.layer_norm(
+    x, scale, offset,
+    implementation=['triton', 'xla'],
+)
+```
+
+## LayerNorm vs. RMSNorm
+
+| Variant | `subtract_mean` | Formula | Models |
+|---|---|---|---|
+| **LayerNorm** | `True` (default) | `(x - mean) / sqrt(var + ε) * scale + offset` | GPT-2, BERT |
+| **RMSNorm** | `False` | `x / sqrt(mean(x²) + ε) * scale` | LLaMA, Gemini, Mistral |
+
+RMSNorm is ~10-15% faster than LayerNorm because it skips the mean
+computation. It has become the de facto standard for large language models.
+
+## API Reference
+
+### `tokamax.layer_norm`
+
+```python
+tokamax.layer_norm(
+    x: jax.Array,
+    scale: jax.Array | None,
+    offset: jax.Array | None,
+    *,
+    axis: int = -1,
+    epsilon: float = 1e-06,
+    scale_offset: float = 0.0,
+    subtract_mean: bool = True,
+    implementation: Implementation | Sequence[Implementation] | None = None,
+) -> jax.Array
+```
+
+**Arguments:**
+
+- **`x`**: The array to normalize.
+- **`scale`**: Optional 1D array of length `x.shape[axis]`. Multiplicative
+  scale factors applied after normalization.
+- **`offset`**: Optional 1D array of length `x.shape[axis]`. Additive offset
+  applied after scaling.
+- **`axis`**: Axis along which to normalize. Default: `-1` (last axis).
+- **`epsilon`**: Small constant added to the denominator for numeric stability.
+  Default: `1e-6`.
+- **`scale_offset`**: Offset added to scale factors before multiplication, i.e.
+  the result is `normalized * (scale + scale_offset) + offset`. Default: `0.0`.
+- **`subtract_mean`**: If `True`, computes standard LayerNorm (subtract mean
+  before computing variance). If `False`, computes RMSNorm (assumes zero mean).
+  Default: `True`.
+- **`implementation`**: Which backend to use. `None` auto-selects.
+
+**Returns:** Normalized array with the same shape and dtype as `x`.


### PR DESCRIPTION
## Summary

Add dedicated documentation pages for two core ops that previously had no doc pages despite being critical building blocks in Transformer architectures.

## New Pages

### `gated_linear_unit.md` — GLU / SwiGLU / GEGLU

Covers the `tokamax.gated_linear_unit` function:

- **Activation variant table**: SwiGLU, GEGLU, REGLU, GLU, Bilinear
- **Usage examples**: Fused weights `(K, 2, N)` and unfused tuple format
- **Implementation matrix**: `xla` (all platforms), `mosaic` (SM90+), `triton` (GPU)
- **Full API reference** with jaxtyping shape annotations

### `normalization.md` — LayerNorm / RMSNorm

Covers the `tokamax.layer_norm` function:

- **LayerNorm vs. RMSNorm comparison table** with model examples (GPT-2/BERT vs. LLaMA/Gemini)
- **Automatic FP32 upcasting** behavior explained
- **Usage examples**: Standard LayerNorm and RMSNorm (`subtract_mean=False`)
- **Implementation matrix**: `xla` (all platforms), `triton` (GPU)
- **Full API reference** with all parameters documented

### `_toc.yaml` Updates

- Added both new pages under "Op-specific Documentation"
- Clarified existing Splash Attention title to "Dot Product Attention (Splash Attention)"

## Context

The `supported_ops.md` page lists these ops but only as one-liners. Users looking for usage examples, weight formats, or implementation-specific behavior had to read source code directly. These pages bridge that gap.
