### PR TITLE
Add Kimi Delta Attention XLA reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ And the following for both GPU and TPU:
 *   `tokamax.ragged_dot`
     ([Mixture of Experts](https://arxiv.org/abs/2211.15841)).
 
+The following portable XLA reference implementation is available on all
+platforms:
+
+*   `tokamax.kimi_delta_attention`
+    ([Kimi Delta Attention](https://arxiv.org/abs/2510.26692)).
+
 And the following TPU kernels:
 
 *   `tokamax.linear_softmax_cross_entropy_loss`

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -14,3 +14,9 @@ And the following for both GPU and TPU:
 
 *   `tokamax.ragged_dot`
     ([Mixture of Experts](https://arxiv.org/abs/2211.15841)).
+
+The following portable XLA reference implementation is available on all
+platforms:
+
+*   `tokamax.kimi_delta_attention`
+    ([Kimi Delta Attention](https://arxiv.org/abs/2510.26692)).

--- a/tokamax/__init__.py
+++ b/tokamax/__init__.py
@@ -28,6 +28,8 @@ from tokamax._src.hlo_utils import DISABLE_JAX_EXPORT_CHECKS as DISABLE_JAX_EXPO
 from tokamax._src.ops.attention.api import dot_product_attention as dot_product_attention
 from tokamax._src.ops.attention.api import Implementation as DotProductAttentionImplementation
 from tokamax._src.ops.gated_linear_unit.api import gated_linear_unit as gated_linear_unit
+from tokamax._src.ops.kda.api import kimi_delta_attention as kimi_delta_attention
+from tokamax._src.ops.kda.api import Implementation as KimiDeltaAttentionImplementation
 from tokamax._src.ops.linear_softmax_cross_entropy_loss.api import linear_softmax_cross_entropy_loss as linear_softmax_cross_entropy_loss
 from tokamax._src.ops.normalization.api import layer_norm as layer_norm
 from tokamax._src.ops.op import BoundArguments as BoundArguments

--- a/tokamax/_src/ops/kda/__init__.py
+++ b/tokamax/_src/ops/kda/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Kimi Delta Attention op."""
+

--- a/tokamax/_src/ops/kda/api.py
+++ b/tokamax/_src/ops/kda/api.py
@@ -1,0 +1,87 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Kimi Delta Attention API."""
+
+from collections.abc import Sequence
+from typing import Final, Literal, TypeAlias
+
+import jax
+from jaxtyping import Array, Float  # pylint: disable=g-multiple-import,g-importing-member
+from tokamax._src import jaxtyping
+from tokamax._src.ops.kda import base
+
+
+Implementation: TypeAlias = Literal["xla"]
+
+IMPLEMENTATIONS = dict(xla=base.KimiDeltaAttention())
+_DEFAULT_IMPLEMENTATIONS: Final[Sequence[Implementation]] = ("xla",)
+
+
+@jaxtyping.jaxtyped
+def kimi_delta_attention(
+    q: Float[Array, "B T H K"],
+    k: Float[Array, "B T H K"],
+    v: Float[Array, "B T H V"],
+    g: Float[Array, "B T H K"],
+    beta: Float[Array, "B T H"],
+    *,
+    scale: float | None = None,
+    initial_state: Float[Array, "B H K V"] | None = None,
+    output_final_state: bool = False,
+    implementation: Implementation | Sequence[Implementation] | None = None,
+) -> tuple[Float[Array, "B T H V"], Float[Array, "B H K V"] | None]:
+  """Kimi Delta Attention.
+
+  Kimi Delta Attention is a recurrent linear attention module. This portable
+  XLA implementation evaluates the dense recurrence and serves as the reference
+  contract for future chunk-wise implementations.
+
+  Args:
+    q: Query tensor with shape `[B, T, H, K]`.
+    k: Key tensor with shape `[B, T, H, K]`.
+    v: Value tensor with shape `[B, T, H, V]`.
+    g: Per-channel gate tensor in log space, shape `[B, T, H, K]`.
+    beta: Per-token delta-rule learning-rate tensor, shape `[B, T, H]`.
+    scale: Query scale. Defaults to `K ** -0.5`.
+    initial_state: Optional initial recurrent state, shape `[B, H, K, V]`.
+    output_final_state: Whether to return the final recurrent state.
+    implementation: The implementation to use. Only `"xla"` is currently
+      supported.
+
+  Returns:
+    A pair `(output, final_state)`. The output has shape `[B, T, H, V]`.
+    The final state has shape `[B, H, K, V]` when requested, otherwise `None`.
+  """
+  if implementation is None:
+    implementation = _DEFAULT_IMPLEMENTATIONS
+  elif isinstance(implementation, str):
+    implementation = (implementation,)
+  elif not implementation:
+    raise ValueError("`implementation` must not be an empty sequence.")
+
+  if tuple(implementation) != ("xla",):
+    raise NotImplementedError("Only XLA implementation is supported.")
+
+  return IMPLEMENTATIONS["xla"](
+      q=q,
+      k=k,
+      v=v,
+      g=g,
+      beta=beta,
+      scale=scale,
+      initial_state=initial_state,
+      output_final_state=output_final_state,
+  )
+

--- a/tokamax/_src/ops/kda/api_test.py
+++ b/tokamax/_src/ops/kda/api_test.py
@@ -1,0 +1,167 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+import jax
+import jax.numpy as jnp
+from tokamax._src import jaxtyping
+from tokamax._src import numerics
+from tokamax._src.ops.kda import api
+
+
+def _accumulator_dtype(dtype):
+  return jnp.float32
+
+
+def _reference_kda(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    *,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+):
+  acc_dtype = _accumulator_dtype(q.dtype)
+  batch, seq_len, heads, key_dim = q.shape
+  value_dim = v.shape[-1]
+  if scale is None:
+    scale = key_dim**-0.5
+
+  q_h = jnp.swapaxes(q, 1, 2).astype(acc_dtype) * scale
+  k_h = jnp.swapaxes(k, 1, 2).astype(acc_dtype)
+  v_h = jnp.swapaxes(v, 1, 2).astype(acc_dtype)
+  g_h = jnp.swapaxes(g, 1, 2).astype(acc_dtype)
+  beta_h = jnp.swapaxes(beta, 1, 2).astype(acc_dtype)
+  state = jnp.zeros((batch, heads, key_dim, value_dim), dtype=acc_dtype)
+  if initial_state is not None:
+    state += initial_state.astype(acc_dtype)
+  outputs = []
+
+  for t in range(seq_len):
+    state = state * jnp.exp(g_h[:, :, t])[..., None]
+    prediction = jnp.einsum("bhk,bhkv->bhv", k_h[:, :, t], state)
+    residual = v_h[:, :, t] - prediction
+    state = state + jnp.einsum(
+        "bhk,bhv->bhkv",
+        beta_h[:, :, t, None] * k_h[:, :, t],
+        residual,
+    )
+    outputs.append(jnp.einsum("bhk,bhkv->bhv", q_h[:, :, t], state))
+
+  output = jnp.stack(outputs, axis=2)
+  output = jnp.swapaxes(output, 1, 2).astype(q.dtype)
+  return output, state if output_final_state else None
+
+
+def _make_inputs(dtype):
+  q = jax.ShapeDtypeStruct((2, 7, 3, 8), dtype)
+  k = jax.ShapeDtypeStruct((2, 7, 3, 8), dtype)
+  v = jax.ShapeDtypeStruct((2, 7, 3, 5), dtype)
+  g = jax.ShapeDtypeStruct((2, 7, 3, 8), dtype)
+  beta = jax.ShapeDtypeStruct((2, 7, 3), dtype)
+  initial_state = jax.ShapeDtypeStruct((2, 3, 8, 5), jnp.float32)
+  q, k, v, g, beta, initial_state = numerics.random_initialize(
+      (q, k, v, g, beta, initial_state)
+  )
+  q = jax.nn.silu(q)
+  k = jax.nn.silu(k)
+  g = -0.1 * jax.nn.softplus(g)
+  beta = jax.nn.sigmoid(beta)
+  return q, k, v, g, beta, initial_state
+
+
+class KimiDeltaAttentionTest(parameterized.TestCase):
+
+  @parameterized.parameters(jnp.bfloat16, jnp.float32)
+  def test_kimi_delta_attention_matches_reference(self, dtype):
+    q, k, v, g, beta, initial_state = _make_inputs(dtype)
+
+    @jax.jit
+    def f(q, k, v, g, beta, initial_state):
+      return api.kimi_delta_attention(
+          q,
+          k,
+          v,
+          g,
+          beta,
+          initial_state=initial_state,
+          output_final_state=True,
+      )
+
+    output, final_state = f(q, k, v, g, beta, initial_state)
+    ref_output, ref_final_state = _reference_kda(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=initial_state,
+        output_final_state=True,
+    )
+
+    self.assertEqual(output.shape, v.shape)
+    self.assertEqual(output.dtype, q.dtype)
+    self.assertEqual(final_state.shape, initial_state.shape)
+    self.assertEqual(final_state.dtype, jnp.float32)
+    chex.assert_trees_all_close(output, ref_output, atol=0.01, rtol=0.01)
+    chex.assert_trees_all_close(
+        final_state, ref_final_state, atol=0.01, rtol=0.01
+    )
+
+  def test_kimi_delta_attention_gradients_match_reference(self):
+    q, k, v, g, beta, _ = _make_inputs(jnp.float32)
+
+    def loss(fn, q, k, v, g, beta):
+      output, _ = fn(q, k, v, g, beta)
+      return jnp.sum(output * output)
+
+    grad = jax.grad(
+        lambda q, k, v, g, beta: loss(api.kimi_delta_attention, q, k, v, g, beta),
+        argnums=(0, 1, 2, 3, 4),
+    )(q, k, v, g, beta)
+    ref_grad = jax.grad(
+        lambda q, k, v, g, beta: loss(_reference_kda, q, k, v, g, beta),
+        argnums=(0, 1, 2, 3, 4),
+    )(q, k, v, g, beta)
+
+    chex.assert_trees_all_close(grad, ref_grad, atol=0.01, rtol=0.01)
+
+  def test_no_final_state_by_default(self):
+    q, k, v, g, beta, _ = _make_inputs(jnp.float32)
+    output, final_state = api.kimi_delta_attention(q, k, v, g, beta)
+    self.assertEqual(output.shape, v.shape)
+    self.assertIsNone(final_state)
+
+  def test_invalid_shape(self):
+    q, k, v, g, beta, _ = _make_inputs(jnp.float32)
+    with self.assertRaisesRegex(ValueError, "`k` shape"):
+      with jaxtyping.disable_jaxtyping():
+        api.kimi_delta_attention(q, k[:, :-1], v, g, beta)
+
+  def test_unsupported_implementation(self):
+    q, k, v, g, beta, _ = _make_inputs(jnp.float32)
+    with self.assertRaisesRegex(NotImplementedError, "Only XLA"):
+      with jaxtyping.disable_jaxtyping():
+        api.kimi_delta_attention(
+            q, k, v, g, beta, implementation="mosaic_tpu"
+        )
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tokamax/_src/ops/kda/base.py
+++ b/tokamax/_src/ops/kda/base.py
@@ -1,0 +1,172 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Kimi Delta Attention base implementation."""
+
+from typing import Any, TypeAlias, TypeVar
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float  # pylint: disable=g-multiple-import,g-importing-member
+from tokamax._src import jaxtyping
+from tokamax._src.ops import op
+from typing_extensions import override
+
+
+_Config = TypeVar("_Config")
+_Key = TypeVar("_Key")
+Output: TypeAlias = tuple[jax.Array, jax.Array | None]
+Residuals: TypeAlias = None
+
+
+def _accumulator_dtype(dtype: jax.typing.DTypeLike) -> jnp.dtype:
+  dtype = jnp.dtype(dtype)
+  return jnp.float64 if dtype == jnp.float64 else jnp.float32
+
+
+def _check_array_rank(x: jax.Array, rank: int, name: str):
+  if x.ndim != rank:
+    raise ValueError(f"`{name}` must be rank {rank}, got shape {x.shape}.")
+
+
+class KimiDeltaAttention(op.Op[Any, Output, Residuals, _Config, _Key]):
+  """Kimi Delta Attention.
+
+  This XLA implementation evaluates the recurrent KDA update:
+
+    S' = S * exp(g_t)
+    residual = v_t - k_t^T @ S'
+    S = S' + beta_t * k_t outer residual
+    o_t = scale * q_t^T @ S
+
+  It is intended as the portable reference implementation for accelerated
+  chunk-wise backends.
+  """
+
+  supports_symbolic_shapes = False
+
+  @override
+  def bind(
+      self,
+      q: Float[Array, "B T H K"],
+      k: Float[Array, "B T H K"],
+      v: Float[Array, "B T H V"],
+      g: Float[Array, "B T H K"],
+      beta: Float[Array, "B T H"],
+      *,
+      scale: float | None = None,
+      initial_state: Float[Array, "B H K V"] | None = None,
+      output_final_state: bool = False,
+      return_residuals: bool = False,
+  ) -> op.BoundArguments:
+    """Binds KDA arguments and validates the dense recurrent contract."""
+    _check_array_rank(q, 4, "q")
+    batch, seq_len, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+
+    if k.shape != q.shape:
+      raise ValueError(f"`k` shape {k.shape} must match `q` shape {q.shape}.")
+    if g.shape != q.shape:
+      raise ValueError(f"`g` shape {g.shape} must match `q` shape {q.shape}.")
+    if v.shape != (batch, seq_len, heads, value_dim):
+      raise ValueError(
+          f"`v` shape {v.shape} must be {(batch, seq_len, heads, value_dim)}."
+      )
+    if beta.shape != (batch, seq_len, heads):
+      raise ValueError(
+          f"`beta` shape {beta.shape} must be {(batch, seq_len, heads)}."
+      )
+    if initial_state is not None:
+      expected_state_shape = (batch, heads, key_dim, value_dim)
+      if initial_state.shape != expected_state_shape:
+        raise ValueError(
+            "`initial_state` shape "
+            f"{initial_state.shape} must be {expected_state_shape}."
+        )
+
+    if scale is None:
+      scale = key_dim**-0.5
+
+    return super().bind(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        return_residuals=return_residuals,
+    )
+
+  @jaxtyping.jaxtyped
+  @override
+  def _fwd(
+      self,
+      q: Float[Array, "B T H K"],
+      k: Float[Array, "B T H K"],
+      v: Float[Array, "B T H V"],
+      g: Float[Array, "B T H K"],
+      beta: Float[Array, "B T H"],
+      *,
+      scale: float,
+      initial_state: Float[Array, "B H K V"] | None,
+      output_final_state: bool,
+      return_residuals: bool,
+      config: _Config,
+  ) -> tuple[Output, Residuals]:
+    """Computes KDA with a time-axis scan."""
+    del config, return_residuals  # Unused.
+
+    batch, _, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    acc_dtype = _accumulator_dtype(q.dtype)
+    output_dtype = q.dtype
+
+    q_h = jnp.swapaxes(q, 1, 2).astype(acc_dtype) * scale
+    k_h = jnp.swapaxes(k, 1, 2).astype(acc_dtype)
+    v_h = jnp.swapaxes(v, 1, 2).astype(acc_dtype)
+    g_h = jnp.swapaxes(g, 1, 2).astype(acc_dtype)
+    beta_h = jnp.swapaxes(beta, 1, 2).astype(acc_dtype)
+
+    state = jnp.zeros((batch, heads, key_dim, value_dim), dtype=acc_dtype)
+    if initial_state is not None:
+      state = state + initial_state.astype(acc_dtype)
+
+    def step(state, inputs):
+      q_t, k_t, v_t, g_t, beta_t = inputs
+      state = state * jnp.exp(g_t)[..., None]
+      prediction = jnp.einsum("bhk,bhkv->bhv", k_t, state)
+      residual = v_t - prediction
+      state = state + jnp.einsum(
+          "bhk,bhv->bhkv", beta_t[..., None] * k_t, residual
+      )
+      out = jnp.einsum("bhk,bhkv->bhv", q_t, state)
+      return state, out
+
+    final_state, output_h = jax.lax.scan(
+        step,
+        state,
+        (
+            jnp.moveaxis(q_h, 2, 0),
+            jnp.moveaxis(k_h, 2, 0),
+            jnp.moveaxis(v_h, 2, 0),
+            jnp.moveaxis(g_h, 2, 0),
+            jnp.moveaxis(beta_h, 2, 0),
+        ),
+    )
+    output = jnp.moveaxis(output_h, 0, 1).astype(output_dtype)
+
+    return (output, final_state if output_final_state else None), None
+


### PR DESCRIPTION
## Summary
- add a portable XLA reference implementation for Kimi Delta Attention
- expose tokamax.kimi_delta_attention and document it as a supported portable reference op
- add API tests covering forward correctness, gradients, final-state behavior, and validation

## Tests
- uv run pytest tokamax/_src/ops/kda/api_test.py -q
- uv run python -c "import tokamax; print(tokamax.kimi_delta_attention)"

Note: ruff is not available in the default uv environment for this checkout (uv run ruff fails with No such file or directory).