### PR TITLE
Handle empty groups in Triton ragged-dot VJP

### DIFF
--- a/tokamax/_src/ops/ragged_dot/pallas_triton.py
+++ b/tokamax/_src/ops/ragged_dot/pallas_triton.py
@@ -274,8 +274,17 @@ def _ragged_contracting_dim_dot_kernel(
 
   num_iters = pl.cdiv(jnp.int32(hi - lo), block_k)
   acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
-  acc = jax.lax.fori_loop(0, num_iters - 1, body, acc)
-  acc = body(num_iters - 1, acc, mask_k=True)  # Mask final iteration.
+
+  def nonempty_group(_):
+    group_acc = jax.lax.fori_loop(0, num_iters - 1, body, acc)
+    return body(num_iters - 1, group_acc, mask_k=True)
+
+  acc = jax.lax.cond(
+      num_iters > 0,
+      nonempty_group,
+      lambda _: acc,
+      operand=None,
+  )
   if activation is not None:
     acc = activation(acc)
   out_ref.store(acc.astype(out_ref.dtype))

--- a/tokamax/_src/ops/ragged_dot/pallas_triton_test.py
+++ b/tokamax/_src/ops/ragged_dot/pallas_triton_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 import jax
 import jax.numpy as jnp
+import numpy as np
 from tokamax._src import gpu_utils
 from tokamax._src.ops.ragged_dot import pallas_triton
 from tokamax._src.ops.ragged_dot import test_base
@@ -65,6 +66,32 @@ class PallasTritonRaggedDotTest(test_base.RaggedDotTestBase):
 
     with mock.patch.object(self, "_dot_fn", split_k_dot):
       self.test_quantized0()  # pytype: disable=attribute-error
+
+  def test_vjp_empty_groups(self):
+    lhs = jax.random.normal(
+        jax.random.key(0), (16, 64), dtype=jnp.float32
+    ).astype(jnp.bfloat16)
+    rhs = jax.random.normal(
+        jax.random.key(1), (4, 64, 32), dtype=jnp.float32
+    ).astype(jnp.bfloat16)
+    group_sizes = jnp.array([8, 0, 8, 0], jnp.int32)
+
+    def loss(lhs_arg, rhs_arg):
+      out = self._dot_fn_f32(
+          lhs_arg,
+          rhs_arg,
+          group_sizes=group_sizes,
+          precision=jax.lax.DotAlgorithmPreset.BF16_BF16_F32,
+      )
+      return jnp.sum(out.astype(jnp.float32))
+
+    _, (_, drhs) = jax.jit(jax.value_and_grad(loss, argnums=(0, 1)))(lhs, rhs)
+
+    self.assertFalse(np.asarray(~jnp.isfinite(drhs)).any())
+    np.testing.assert_array_equal(
+        np.asarray(drhs)[np.asarray(group_sizes) == 0],
+        np.zeros_like(np.asarray(drhs)[np.asarray(group_sizes) == 0]),
+    )
 
   @override
   def _test_simple(self, dtype):


### PR DESCRIPTION
## Summary

- Guard the Pallas-Triton ragged contracting-dim kernel when a group is empty.
- Add a GPU regression for the `drhs` VJP path with `group_sizes=[8, 0, 8, 0]`.

The old code always ran the final masked loop body at `num_iters - 1`; for an
empty group that is `-1`, which can produce non-finite expert-weight gradients.

## MWE

```python
import jax
import jax.numpy as jnp
import numpy as np
from tokamax._src.ops.ragged_dot import pallas_triton
from tokamax._src.ops.ragged_dot import test_base

op = pallas_triton.PallasTritonRaggedDot()
group_sizes = jnp.array([8, 0, 8, 0], jnp.int32)
lhs = jax.random.normal(jax.random.key(0), (16, 64), dtype=jnp.float32).astype(jnp.bfloat16)
rhs = jax.random.normal(jax.random.key(1), (4, 64, 32), dtype=jnp.float32).astype(jnp.bfloat16)

def loss(lhs_arg, rhs_arg):
  out = test_base._dot_fn_f32(op)(
      lhs_arg,
      rhs_arg,
      group_sizes=group_sizes,
      precision=jax.lax.DotAlgorithmPreset.BF16_BF16_F32,
  )
  return jnp.sum(out.astype(jnp.float32))

_, (_, drhs) = jax.jit(jax.value_and_grad(loss, argnums=(0, 1)))(lhs, rhs)
print(int(np.asarray(~jnp.isfinite(drhs)).sum()))
print(int(np.asarray(~jnp.isfinite(drhs))[np.asarray(group_sizes) == 0].sum()))
```

On `tokamax==0.0.12` before this patch:

```text
drhs_nonfinite 154
empty_group_nonfinite 154
```

## Tested

Hardware/runtime:

- NVIDIA H100 80GB HBM3
- NVIDIA driver 580.126.20, CUDA 13.0
- Python 3.12.3, NumPy 2.5.1
- JAX 0.10.2, jaxlib 0.10.2

Command:

```bash
pytest -q tokamax/_src/ops/ragged_dot/pallas_triton_test.py::PallasTritonRaggedDotTest::test_vjp_empty_groups
```

Result:

```text
1 passed
```
