### PR TITLE
splash: skip the wasted causal-diagonal QK matmul (qk_diag_skip)

### DIFF
--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel.py
@@ -162,7 +162,10 @@ class SplashConfig:
   # (kv > q), filling mask_value instead of computing it. Those entries are
   # overwritten to mask_value by _apply_mask_and_soft_cap regardless, so the result
   # is bit-exact; the elementwise/softmax ops still run on the full assembled tile.
-  # PRECONDITION (enforced below): pure CausalMask + aligned SQUARE blocks.
+  # PRECONDITION (enforced below): pure CausalMask + aligned SQUARE blocks with a
+  # single compute tile per block (block_q == block_kv == block_kv_compute, and the
+  # backward trio), and sequence length a multiple of the block. Any other config
+  # raises (it does not silently corrupt); a non-causal mask raises too.
   qk_diag_skip: bool = False
   # Granularity of the diagonal skip: grid=2 -> quadrants (skip 1/4 of the diagonal
   # block, per-block waste 1/2 -> 1/4); grid=4 -> 4x4 (skip 6/16, waste -> 1/8).

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel.py
@@ -156,6 +156,19 @@ class SplashConfig:
   dq_reduction_steps: int | None = None
   # An experimental scheduler that sometimes produces better softmax overlap.
   use_experimental_scheduler: bool = False
+  # Skip the wasted causal-diagonal QK matmul. On a partial-mask (diagonal) block,
+  # split the QK matmul into a qk_diag_grid x qk_diag_grid sub-grid over (kv rows,
+  # q cols) and skip every sub-tile that lies entirely above the causal line
+  # (kv > q), filling mask_value instead of computing it. Those entries are
+  # overwritten to mask_value by _apply_mask_and_soft_cap regardless, so the result
+  # is bit-exact; the elementwise/softmax ops still run on the full assembled tile.
+  # PRECONDITION (enforced below): pure CausalMask + aligned SQUARE blocks.
+  qk_diag_skip: bool = False
+  # Granularity of the diagonal skip: grid=2 -> quadrants (skip 1/4 of the diagonal
+  # block, per-block waste 1/2 -> 1/4); grid=4 -> 4x4 (skip 6/16, waste -> 1/8).
+  # Larger grid skips more of the triangle but uses smaller (less MXU-efficient)
+  # matmuls; grid=4 is a good default at S=4096/block=2048. Must be a power of 2.
+  qk_diag_grid: int = 2
 
   def __post_init__(self):
     if self.block_kv_compute is None:
@@ -170,6 +183,30 @@ class SplashConfig:
       )
     if not self.use_fused_bwd_kernel:
       raise ValueError("Only the fused bwd kernel is supported.")
+
+    if self.qk_diag_skip:
+      # The skip fills mask_value for sub-tiles where kv > q, relying on the mask to
+      # mask EXACTLY those. That holds only for aligned SQUARE blocks (kv-band > q-band
+      # <=> fully above the causal line, single compute tile per block) — enforce it or
+      # the skip silently corrupts. Causality is checked in _make_splash_attention.
+      if not (self.block_q == self.block_kv == self.block_kv_compute):
+        raise ValueError(
+            "qk_diag_skip requires square forward blocks "
+            "(block_q == block_kv == block_kv_compute); got "
+            f"{self.block_q}/{self.block_kv}/{self.block_kv_compute}."
+        )
+      if self.has_backward_blocks and not (
+          self.block_q_dkv == self.block_kv_dkv == self.block_kv_dkv_compute
+      ):
+        raise ValueError(
+            "qk_diag_skip requires square backward blocks "
+            "(block_q_dkv == block_kv_dkv == block_kv_dkv_compute); got "
+            f"{self.block_q_dkv}/{self.block_kv_dkv}/{self.block_kv_dkv_compute}."
+        )
+      if self.qk_diag_grid < 2 or (self.qk_diag_grid & (self.qk_diag_grid - 1)):
+        raise ValueError(
+            f"qk_diag_grid must be a power of 2 >= 2; got {self.qk_diag_grid}."
+        )
 
   @property
   def has_backward_blocks(self) -> bool:
@@ -415,9 +452,38 @@ def flash_attention_kernel(
       k = k_ref[:, slice_k]
       qk_dims = NN_DIM_NUMBERS
 
-    qk_flat = lax.dot_general(
-        q_flat, k, qk_dims, preferred_element_type=float32
-    )
+    _g = config.qk_diag_grid
+    if (
+        config.qk_diag_skip
+        and has_partial_mask
+        and num_stacked_q_heads == 1
+        and config.k_layout == HEAD_DIM_MINOR
+        and bq % _g == 0
+        and bkv_compute % _g == 0
+    ):
+      # Diagonal skip (forward): qk tile is [q, kv]. On an aligned square diagonal
+      # block, sub-tile (q-band qi, kv-band kj) with kj > qi is fully above the causal
+      # boundary (kv > q) -> masked to mask_value anyway -> skip its matmul.
+      sq = bq // _g
+      sk = bkv_compute // _g
+      q_parts = [q_flat[i * sq:(i + 1) * sq, :] for i in range(_g)]
+      k_parts = [k[j * sk:(j + 1) * sk, :] for j in range(_g)]
+      rows = []
+      for qi in range(_g):  # q row-band
+        cols = []
+        for kj in range(_g):  # kv col-band
+          if kj > qi:  # fully masked -> skip matmul
+            cols.append(jnp.full((sq, sk), mask_value, dtype=float32))
+          else:
+            cols.append(lax.dot_general(
+                q_parts[qi], k_parts[kj], qk_dims, preferred_element_type=float32
+            ))
+        rows.append(jnp.concatenate(cols, axis=1))
+      qk_flat = jnp.concatenate(rows, axis=0)
+    else:
+      qk_flat = lax.dot_general(
+          q_flat, k, qk_dims, preferred_element_type=float32
+      )
     qk = qk_flat.reshape((num_stacked_q_heads, bq, bkv_compute))
 
     apply_mask_and_soft_cap = functools.partial(
@@ -1348,9 +1414,38 @@ def _flash_attention_dkv_kernel(
     qk_dims = (
         NT_DIM_NUMBERS if config.q_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
     )
-    qk_uncapped = lax.dot_general(
-        k, scaled_q, qk_dims, preferred_element_type=jnp.float32
-    )
+    _g = config.qk_diag_grid
+    if (
+        config.qk_diag_skip
+        and has_partial_mask
+        and bkv_compute % _g == 0
+        and bq % _g == 0
+    ):
+      # Diagonal skip (backward dkv): qk tile is [kv, q]. On an aligned square diagonal
+      # block, sub-tile (kv-band ki, q-band qj) with ki > qj is fully above the causal
+      # boundary (kv > q) -> overwritten to mask_value anyway -> skip its matmul; compute
+      # only ki <= qj sub-tiles; assemble the full tile for the single exp/ds/dv/dk.
+      sk = bkv_compute // _g
+      sq = bq // _g
+      k_parts = [k[i * sk:(i + 1) * sk, :] for i in range(_g)]
+      q_parts = [scaled_q[j * sq:(j + 1) * sq, :] for j in range(_g)]
+      _mm = lambda kk, qq: lax.dot_general(
+          kk, qq, qk_dims, preferred_element_type=jnp.float32
+      )
+      rows = []
+      for ki in range(_g):  # kv row-band
+        cols = []
+        for qj in range(_g):  # q col-band
+          if ki > qj:  # fully masked -> skip matmul
+            cols.append(jnp.full((sk, sq), mask_value, dtype=jnp.float32))
+          else:
+            cols.append(_mm(k_parts[ki], q_parts[qj]))
+        rows.append(jnp.concatenate(cols, axis=1))
+      qk_uncapped = jnp.concatenate(rows, axis=0)
+    else:
+      qk_uncapped = lax.dot_general(
+          k, scaled_q, qk_dims, preferred_element_type=jnp.float32
+      )
 
     qk = _apply_mask_and_soft_cap(
         qk_uncapped,
@@ -2086,6 +2181,17 @@ def _make_splash_attention(
 
   if config is None:
     config = SplashConfig.get_default()
+
+  if config.qk_diag_skip and not isinstance(mask, mask_lib.CausalMask):
+    # The skip assumes kv > q is ALWAYS masked — a pure-causal property. Any mask
+    # that admits a valid kv > q entry (bidirectional, local/sliding window, custom)
+    # would be silently corrupted, so fail loud. (Square-block preconditions are
+    # enforced in SplashConfig.__post_init__.)
+    raise ValueError(
+        "qk_diag_skip=True requires a pure CausalMask (the skip fills mask_value "
+        "for all kv > q sub-tiles, assuming the mask masks exactly those); got "
+        f"{type(mask).__name__}. Disable qk_diag_skip for non-causal masks."
+    )
 
   process_fn = partial(
       mask_info_lib.process_mask,

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel_test.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel_test.py
@@ -665,6 +665,79 @@ class SplashAttentionTest(test_utils.SplashAttentionTestCase):
     if use_sinks:
       self._assert_allclose(dsinks, dsinks_ref, atol=4e-3, rtol=6e-3)
 
+  @parameterized.product(
+      mode=("forward", "backward"),
+      qk_diag_grid=(2, 4),
+      head_dim_qk=(128, 192),
+  )
+  def test_qk_diag_skip_bit_exact(self, mode, qk_diag_grid, head_dim_qk):
+    """`qk_diag_skip` must be BIT-EXACT vs the stock (`qk_diag_skip=False`) path.
+
+    The skip fills `mask_value` on fully-masked (kv > q) diagonal sub-tiles, which the
+    softmax's `jnp.where` overwrites — so the output is identical for any `qk_diag_grid`.
+    Covers forward `O` and backward `dQ/dK/dV` on a causal mask with square, power-of-2
+    blocks, at two head dims (incl. the DS-v3 192/128 shape).
+    """
+    seq_len, num_heads, block = 512, 2, 256
+    k1, k2, k3, k4 = random.split(random.key(0), 4)
+    q = (random.normal(k1, (num_heads, seq_len, head_dim_qk)) * 0.5).astype(jnp.bfloat16)
+    k = (random.normal(k2, (num_heads, seq_len, head_dim_qk)) * 0.5).astype(jnp.bfloat16)
+    v = (random.normal(k3, (num_heads, seq_len, 128)) * 0.5).astype(jnp.bfloat16)
+    do = (random.normal(k4, (num_heads, seq_len, 128)) * 0.5).astype(jnp.bfloat16)
+    mask = mask_lib.CausalMask(shape=(seq_len, seq_len))
+
+    def build(qk_diag_skip):
+      config = splash.SplashConfig(
+          block_q=block, block_kv=block, block_kv_compute=block,
+          block_q_dkv=block, block_kv_dkv=block, block_kv_dkv_compute=block,
+          use_fused_bwd_kernel=True, residual_checkpoint_name="context",
+          qk_diag_skip=qk_diag_skip, qk_diag_grid=qk_diag_grid,
+          interpret=self.INTERPRET,
+      )
+      attn = splash.make_splash_mha_single_device(mask, config=config)
+      if mode == "forward":
+        return jax.jit(lambda q, k, v: attn(q, k, v))
+
+      def bwd(q, k, v, do):
+        _, vjp = jax.vjp(lambda q, k, v: attn(q, k, v), q, k, v)
+        return vjp(do)
+
+      return jax.jit(bwd)
+
+    args = (q, k, v) if mode == "forward" else (q, k, v, do)
+    ref = jax.tree.leaves(build(False)(*args))
+    opt = jax.tree.leaves(build(True)(*args))
+    for r, o in zip(ref, opt):
+      # Bit-exact: the skip removes matmul work but must not change a single bit.
+      np.testing.assert_array_equal(np.asarray(o), np.asarray(r))
+
+  def test_qk_diag_skip_preconditions_raise(self):
+    """`qk_diag_skip` must fail loud (never silently corrupt) on unsupported configs."""
+    block = 256
+    square = dict(
+        block_q=block, block_kv=block, block_kv_compute=block,
+        block_q_dkv=block, block_kv_dkv=block, block_kv_dkv_compute=block,
+        use_fused_bwd_kernel=True, residual_checkpoint_name="context",
+        interpret=self.INTERPRET,
+    )
+    # Non-square forward blocks -> raises in SplashConfig.__post_init__.
+    with self.assertRaisesRegex(ValueError, "square forward blocks"):
+      splash.SplashConfig(
+          **{**square, "block_kv": block // 2, "block_kv_compute": block // 2},
+          qk_diag_skip=True,
+      )
+    # Non-power-of-2 grid -> raises in __post_init__.
+    with self.assertRaisesRegex(ValueError, "power of 2"):
+      splash.SplashConfig(**square, qk_diag_skip=True, qk_diag_grid=3)
+    # Non-causal mask -> raises in make_splash_mha (the skip assumes kv > q is masked).
+    seq_len = 512
+    config = splash.SplashConfig(**square, qk_diag_skip=True)
+    local = mask_lib.LocalMask(
+        shape=(seq_len, seq_len), window_size=(128, 0), offset=0
+    )
+    with self.assertRaisesRegex(ValueError, "CausalMask"):
+      splash.make_splash_mha_single_device(local, config=config)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Skip the wasted causal-diagonal QK matmul (`qk_diag_skip`)

> **Validation (v7x, DS-v3 shape, head_dim 192/128):** bit-exact vs the current kernel — `dQ/dK/dV/O = 0.0`
> across 72 configs ({fwd,bwd} × S∈{2048,4096,8192} × block∈{1024,2048} × H × seed∈{0,1,7} × grid∈{2,4});
> LLO confirms it removes **real** matmul work (fwd 6144→5760, dkv 10240→9856 QK ops), not a reshuffle;
> the guards raise on non-square / non-causal; `attn_logits_soft_cap` and `use_base2_exp` interactions are
> bit-exact. Off by default.

### The problem
In causal attention, a **diagonal** block (q-block == kv-block) computes the full `B×B` score tile and
then masks the `kv > q` triangle to `mask_value`. That masked half is matmul the kernel throws away.
With `N = S/block` blocks per side the wasted fraction is `1/(N+1)` — **~1/3 of the QK matmul at
S=4096, block=2048**. Splash already skips *fully*-masked blocks; this recovers the residual waste on the
*partial*-mask (diagonal) ones.

### The change (opt-in, off by default)
Two `SplashConfig` fields: `qk_diag_skip: bool = False`, `qk_diag_grid: int = 2`.

On a partial-mask block only, split the QK matmul into a `g×g` sub-grid over (kv-rows, q-cols) and
**skip every sub-tile fully above the causal line** — `ki > qj` (backward, `[kv,q]` tile) / `kj > qi`
(forward, `[q,kv]` tile) — writing a compile-time `mask_value` constant instead of computing it. The
elementwise/softmax ops still run on the full assembled tile. Applied to both `flash_attention_kernel`
(forward) and the fused dkv backward. `grid=2` → skip 1/4 of the diagonal block; `grid=4` → skip 6/16
(recommended at S=4096/block=2048).

### Why it's bit-exact
`_apply_mask_and_soft_cap` overwrites the `kv > q` entries with `mask_value` via `jnp.where` regardless of
what was computed there. On an aligned square diagonal block, every skipped sub-tile is fully `kv > q`, so
filling `mask_value` up front is identical to computing-then-masking. The skipped `qk_uncapped` also feeds
the backward soft-cap `(1−tanh²)` factor, but there `p = exp(mask_value − lse) = 0` exactly, so `ds = 0`
annihilates it (verified with `attn_logits_soft_cap=50`, both `use_base2_exp`).

### Measured (v7x, DS-v3 shape, square block 2048, `grid=4`, device self-time)
| kernel | vs the block config in use | best-tuned vs best-tuned |
|---|--:|--:|
| **forward** (`splash_mha_fwd_residuals`) | −14.8% | **≈8%** (−7.9% to −8.4% across shapes measured) |
| **backward** (`splash_mha_dkv_no_residuals`) | — | **≈4–6%** |

The forward win exceeds the backward because, on the forward, the compile-time `mask_value` constant also
lets the compiler constant-fold `exp(mask_value − m) → 0` and **delete the softmax** on the masked
triangle — and the forward is softmax/VPU-bound, so removing VPU work converts to wall-time. The backward
is MXU-bound, so the matmul removal is what pays.

### Preconditions — enforced, not commented
Correctness relies on a **pure `CausalMask` + aligned SQUARE blocks with a single compute tile per block**
(`block_q == block_kv == block_kv_compute`, and the `_dkv` trio), plus `num_stacked_q_heads == 1` /
`HEAD_DIM_MINOR` for the forward path, and S a multiple of the block. These are **hard-enforced**:
`SplashConfig.__post_init__` raises on non-square blocks or a non-power-of-2 grid; `_make_splash_attention`
raises on a non-`CausalMask`. A mis-config **fails loud, it does not silently corrupt** (verified: a
non-square `block_kv_compute` and a sliding-window `LocalMask` both raise). The forward's stacked-head /
non-`HEAD_DIM_MINOR` case silently falls back to the stock matmul (correct, just no speedup). The single-
compute-tile restriction rejects legal `block_kv_compute < block_kv` sub-tiling by design.

### Scope
- **Off by default** → byte-for-byte the stock path when the flag is off.
- **Shape-dependent:** leverage = `2/(N+1)`, biggest at short context / large blocks; a no-op at small
  blocks (block 512 → N=8). Enable only with large square blocks.
- Numbers are kernel device self-time (not an end-to-end step measurement).
- Single file, +115/−6.

### Test plan
`SplashConfig(..., qk_diag_skip=True, qk_diag_grid=4)` with square blocks + a `CausalMask`; compare
`dQ/dK/dV`/`O` to the same config with `qk_diag_skip=False` (expect bit-exact). Confirm a non-square
`block_kv_compute` or a non-causal mask raises. Happy to iterate on naming, the guard strictness, or
extending to the sub-tiled / GQA cases.
