### PR TITLE
Add jax_triton implementation of normalization op

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ cuda = [
     "nvidia-cudnn-cu13>=9.23.0.39",
     "cuequivariance-jax>=0.10.0",
     "cuequivariance-ops-jax-cu13>=0.10.0",
-    "triton"
+    "triton",
+    "jax-triton",
 ]
 
 tpu = [

--- a/tokamax/_src/ops/normalization/bench.py
+++ b/tokamax/_src/ops/normalization/bench.py
@@ -63,4 +63,4 @@ def _register_benchmarks():
 
 if __name__ == '__main__':
   app.call_after_init(_register_benchmarks)
-  google_benchmark.main()
+  app.run(lambda _: google_benchmark.main())

--- a/tokamax/_src/ops/normalization/bench.py
+++ b/tokamax/_src/ops/normalization/bench.py
@@ -18,11 +18,15 @@ import functools
 from absl import app
 from absl import flags
 import google_benchmark
+from tokamax._src import batching
 from tokamax._src import benchmarking
 from tokamax._src.ops.normalization import base
 from tokamax._src.ops.normalization import jax_triton as jt_norm
 from tokamax._src.ops.normalization import pallas_triton as pl_norm
 from tokamax._src.ops.normalization import arg_specs
+
+# Batch size for the batched (`vmap`) benchmarks.
+_VMAP_BATCH = 8
 
 
 _IMPLS = dict(
@@ -42,20 +46,42 @@ _BENCHMARK_IMPLS_FWD_BWD = flags.DEFINE_list(
 )
 
 
+def _batched_args(args):
+  """Returns `args` with x batched over a new leading axis (`scale`/`offset`
+
+  shared). All array args become `batching.BatchedShapeDtype`, which the
+  benchmark harness turns into a `jax.vmap` over the op — exercising the
+  batching (fold-into-M) path.
+  """
+  def batched(sds, vmapped):
+    vmap_axes = ((0, _VMAP_BATCH),) if vmapped else (None,)
+    return batching.BatchedShapeDtype(sds.shape, sds.dtype, vmap_axes)
+
+  out = dict(args)
+  out['x'] = batched(args['x'], True)
+  for k in ('scale', 'offset'):
+    if args[k] is not None:
+      out[k] = batched(args[k], False)
+  return out
+
+
 def _register_benchmarks():
   """Registers benchmarks."""
   register_benchmark = functools.partial(
       benchmarking.register_benchmark, iterations=10
   )
 
-  for arg_spec in arg_specs.ARG_SPECS:
+  # Non-batched and batched (`vmap`) variants of each arg spec.
+  specs = [(s.full_name, s.args) for s in arg_specs.ARG_SPECS]
+  specs += [(f'{s.full_name}_vmap', _batched_args(s.args)) for s in
+            arg_specs.ARG_SPECS]
+
+  for name, kwargs in specs:
     for impl_name in _BENCHMARK_IMPLS_FWD.value:
       impl = _IMPLS[impl_name]
-      register_benchmark(arg_spec.full_name, impl_name, impl, arg_spec.args)
+      register_benchmark(name, impl_name, impl, kwargs)
 
-  for arg_spec in arg_specs.ARG_SPECS:
-    name = arg_spec.full_name
-    kwargs = arg_spec.args
+  for name, kwargs in specs:
     for impl_name in _BENCHMARK_IMPLS_FWD_BWD.value:
       impl = _IMPLS[impl_name]
       register_benchmark(name, impl_name, impl, kwargs, mode='forward_and_vjp')

--- a/tokamax/_src/ops/normalization/bench.py
+++ b/tokamax/_src/ops/normalization/bench.py
@@ -20,12 +20,14 @@ from absl import flags
 import google_benchmark
 from tokamax._src import benchmarking
 from tokamax._src.ops.normalization import base
+from tokamax._src.ops.normalization import jax_triton as jt_norm
 from tokamax._src.ops.normalization import pallas_triton as pl_norm
 from tokamax._src.ops.normalization import arg_specs
 
 
 _IMPLS = dict(
     pallas=pl_norm.PallasTritonNormalization(input_output_alias=False),
+    jax_triton=jt_norm.JaxTritonNormalization(input_output_alias=False),
     xla=base.Normalization(),
 )
 _BENCHMARK_IMPLS_FWD = flags.DEFINE_list(

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -15,6 +15,7 @@
 """Native Triton normalization op via jax-triton."""
 
 import dataclasses
+import functools
 from typing import ClassVar, TypeAlias
 
 import jax
@@ -38,6 +39,38 @@ VjpKey: TypeAlias = triton_vjp_config.Key
 FusedInputArray = base.FusedInputArray
 Residuals = base.Residuals
 _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
+
+
+def _vmappable(launch):
+  """Adds a `jax.vmap` batching rule to a `jt.triton_call` `launch(*arrays)`.
+
+  `jt.triton_call` raises under `vmap` (the batching rule is inherently
+  per-kernel, so jax-triton refuses to guess). Normalization batching is just
+  extra rows, so we fold the batch axis with `lax.map`, whose body launches the
+  kernel per slice with no `vmap` tracer. Correct for batched `scale`/`offset`
+  and nested `vmap`. Outside `vmap` this calls `launch` directly (no overhead).
+  """
+  f = jax.custom_batching.custom_vmap(launch)
+
+  @f.def_vmap
+  def _rule(axis_size, in_batched, *arrays):
+    del axis_size
+    idx = [i for i, b in enumerate(in_batched) if b]
+    if not idx:  # Nothing batched (shouldn't happen under `vmap`).
+      return launch(*arrays), in_batched
+
+    def body(slices):
+      full = list(arrays)
+      for i, s in zip(idx, slices):
+        full[i] = s
+      # Call `f` (not `launch`): under nested `vmap` the inner batch axis is
+      # still live here, and must re-enter this rule (→ nested `lax.map`).
+      return f(*full)
+
+    out = jax.lax.map(body, tuple(arrays[i] for i in idx))
+    return out, jax.tree.map(lambda _: True, out)
+
+  return f
 
 
 # ── Forward kernel ─────────────────────────────────────────────────────────────
@@ -292,8 +325,8 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
         jax.ShapeDtypeStruct((num_rows,), jnp.float32),
         jax.ShapeDtypeStruct((num_rows,), jnp.float32),
     ]
-    y, mean_flat, rstd_flat = jt.triton_call(
-        x, scale_arr, offset_arr,
+    launch = _vmappable(functools.partial(
+        jt.triton_call,
         kernel=_normalization_kernel,
         out_shape=out_shapes,
         grid=grid,
@@ -315,7 +348,8 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
         RETURN_MEAN=return_residuals and subtract_mean,
         RETURN_RSTD=return_residuals,
         SINGLE_N=single_n,
-    )
+    ))
+    y, mean_flat, rstd_flat = launch(x, scale_arr, offset_arr)
 
     y = y.reshape(orig_x_shape)
 
@@ -431,8 +465,8 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
         dparam_shape if scale is not None else dummy_shape,
         dparam_shape if offset is not None else dummy_shape,
     ]
-    dx, dscale_partial, doffset_partial = jt.triton_call(
-        dout, x, scale_arr, mean_flat, rstd_flat,
+    launch = _vmappable(functools.partial(
+        jt.triton_call,
         kernel=_normalization_vjp_kernel,
         out_shape=out_shapes,
         grid=grid,
@@ -452,7 +486,9 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
         HAS_OFFSET=offset is not None,
         SUBTRACT_MEAN=subtract_mean,
         SINGLE_N=grid_n == 1,
-    )
+    ))
+    dx, dscale_partial, doffset_partial = launch(
+        dout, x, scale_arr, mean_flat, rstd_flat)
 
     dscale = None
     if scale is not None:

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -62,22 +62,20 @@ def _normalization_kernel(
 ):
   """Normalization forward kernel (layer norm / RMS norm).
 
-  Input buffer is canonicalized (M, A, N) with A the norm axis, but the
-  in-register tile is laid out (M, N, A) so the reduced axis A is innermost.
-  This lets Triton lane-map the reduction efficiently even when N == 1 (the
-  axis=-1 case), matching Pallas without a separate 2D kernel.
+  Operates on a canonicalized (M, A, N) layout where A is the (middle) norm
+  axis and N is contiguous. 2D grid (pid_m, pid_n) tiles over M and N; each
+  program reduces a full (BLOCK_M, A, BLOCK_N) tile along A.
   """
   pid_m = tl.program_id(0)
   pid_n = tl.program_id(1)
   m_off = pid_m * BLOCK_M
   n_off = pid_n * BLOCK_N
 
-  # (M, N, A) view: N contiguous (stride 1), A strided by N. order lists dims
-  # minor→major: N (stride 1), A (stride N), M (stride A*N).
+  # (M, A, N) tile: N contiguous (stride 1), A strided by N.
   x_blk = tl.make_block_ptr(
-      X, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
-      offsets=(m_off, n_off, 0),
-      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
+      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(m_off, 0, n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   )
   x = tl.load(x_blk, boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
 
@@ -85,7 +83,7 @@ def _normalization_kernel(
   a_mask = a_offs < A
 
   if SUBTRACT_MEAN:
-    mean = tl.sum(x, axis=2) / A
+    mean = tl.sum(x, axis=1) / A
     if RETURN_MEAN:
       mean_blk = tl.make_block_ptr(
           MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
@@ -93,11 +91,11 @@ def _normalization_kernel(
           block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
       )
       tl.store(mean_blk, mean, boundary_check=(0, 1))
-    x = x - mean[:, :, None]
+    x = x - tl.expand_dims(mean, 1)
     # Zero invalid values (when A is not a power of two).
-    x = tl.where(a_mask[None, None, :], x, 0.0)
+    x = tl.where(a_mask[None, :, None], x, 0.0)
 
-  var = tl.sum(x * x, axis=2) / A
+  var = tl.sum(x * x, axis=1) / A
   rstd = 1.0 / tl.sqrt(var + epsilon)
   if RETURN_RSTD:
     rstd_blk = tl.make_block_ptr(
@@ -106,19 +104,19 @@ def _normalization_kernel(
         block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
     )
     tl.store(rstd_blk, rstd, boundary_check=(0, 1))
-  x = x * rstd[:, :, None]
+  x = x * tl.expand_dims(rstd, 1)
 
   if HAS_SCALE:
     s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    x = x * (s[None, None, :] + scale_offset)
+    x = x * (s[None, :, None] + scale_offset)
   if HAS_OFFSET:
     o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    x = x + o[None, None, :]
+    x = x + o[None, :, None]
 
   y_blk = tl.make_block_ptr(
-      Y, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
-      offsets=(m_off, n_off, 0),
-      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
+      Y, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(m_off, 0, n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   )
   tl.store(y_blk, x.to(Y.dtype.element_ty), boundary_check=(0, 1, 2))
 
@@ -143,9 +141,9 @@ def _normalization_vjp_kernel(
 ):
   """Normalization VJP kernel.
 
-  In-register tile is laid out (M, N, A) with A innermost (see forward kernel).
   2D grid (pid_m, pid_n). Produces per-program partial sums for dscale and
-  doffset (shape (grid_m * grid_n, A)), reduced outside the kernel.
+  doffset (shape (grid_m * grid_n, A)), reduced outside the kernel. Operates on
+  the canonical (M, A, N) layout, reducing along the middle axis A.
   """
   pid_m = tl.program_id(0)
   pid_n = tl.program_id(1)
@@ -155,11 +153,11 @@ def _normalization_vjp_kernel(
   a_offs = tl.arange(0, BLOCK_A)
   a_mask = a_offs < A
 
-  # Compute x_norm = (x - mean) * rstd. Tile viewed as (M, N, A), A innermost.
+  # Compute x_norm = (x - mean) * rstd. (M, A, N) tile, N contiguous.
   x_norm = tl.load(tl.make_block_ptr(
-      X, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
-      offsets=(m_off, n_off, 0),
-      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
+      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(m_off, 0, n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
   if SUBTRACT_MEAN:
     mean = tl.load(tl.make_block_ptr(
@@ -167,48 +165,48 @@ def _normalization_vjp_kernel(
         offsets=(m_off, n_off),
         block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
     ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-    x_norm = x_norm - mean[:, :, None]
+    x_norm = x_norm - tl.expand_dims(mean, 1)
   rstd = tl.load(tl.make_block_ptr(
       RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
       offsets=(m_off, n_off),
       block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
   ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-  x_norm = x_norm * rstd[:, :, None]
+  x_norm = x_norm * tl.expand_dims(rstd, 1)
 
   # Load dout tile.
   dout = tl.load(tl.make_block_ptr(
-      DOUT, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
-      offsets=(m_off, n_off, 0),
-      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
+      DOUT, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(m_off, 0, n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
 
-  # Partial doffset/dscale: reduce (BM, BN, BA) over M and N → (BA,).
+  # Partial doffset/dscale: reduce (BM, BA, BN) over M and N → (BA,).
   # Store as (linear_pid, A); host sums axis 0 to get (A,).
   linear_pid = pid_m * grid_n + pid_n
 
   if HAS_OFFSET:
-    doffset = tl.sum(tl.sum(dout, axis=1), axis=0)
+    doffset = tl.sum(tl.sum(dout, axis=2), axis=0)
     tl.store(DOFFSET + linear_pid * A + a_offs, doffset, mask=a_mask)
 
   if HAS_SCALE:
-    dscale = tl.sum(tl.sum(dout * x_norm, axis=1), axis=0)
+    dscale = tl.sum(tl.sum(dout * x_norm, axis=2), axis=0)
     tl.store(DSCALE + linear_pid * A + a_offs, dscale, mask=a_mask)
     s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    dout = dout * (s[None, None, :] + scale_offset)
+    dout = dout * (s[None, :, None] + scale_offset)
 
   # dx = (dout - mean_a(dout·x_norm)·x_norm [- mean_a(dout)]) * rstd
-  # Reductions over axis 2 (the A dimension).
-  dx1 = -(tl.sum(dout * x_norm, axis=2) / A)
-  dx = dout + dx1[:, :, None] * x_norm
+  # Reductions over axis 1 (the A dimension).
+  dx1 = tl.expand_dims(-(tl.sum(dout * x_norm, axis=1) / A), 1)
+  dx = dout + dx1 * x_norm
   if SUBTRACT_MEAN:
-    dx2 = -(tl.sum(dout, axis=2) / A)
-    dx = dx + dx2[:, :, None]
-  dx = dx * rstd[:, :, None]
+    dx2 = tl.expand_dims(-(tl.sum(dout, axis=1) / A), 1)
+    dx = dx + dx2
+  dx = dx * tl.expand_dims(rstd, 1)
 
   tl.store(tl.make_block_ptr(
-      DX, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
-      offsets=(m_off, n_off, 0),
-      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
+      DX, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(m_off, 0, n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   ), dx.to(DX.dtype.element_ty), boundary_check=(0, 1, 2))
 
 

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -59,15 +59,24 @@ def _normalization_kernel(
     SUBTRACT_MEAN: tl.constexpr,
     RETURN_MEAN: tl.constexpr,
     RETURN_RSTD: tl.constexpr,
+    SINGLE_N: tl.constexpr,
 ):
   """Normalization forward kernel (layer norm / RMS norm).
 
   Operates on a canonicalized (M, A, N) layout where A is the (middle) norm
   axis and N is contiguous. 2D grid (pid_m, pid_n) tiles over M and N; each
   program reduces a full (BLOCK_M, A, BLOCK_N) tile along A.
+
+  When the N grid is degenerate (`SINGLE_N`, i.e. `cdiv(N, BLOCK_N) == 1`) the N
+  program id is folded to a compile-time 0. Otherwise `n_off = program_id(1) *
+  BLOCK_N` is a runtime value on the contiguous (stride-1) N axis of the block
+  pointer, which defeats Triton's alignment/divisibility proof and blocks
+  vectorization of the reduction axis (scalar, cross-warp layout). Folding it —
+  as Pallas/XLA do for size-1 grid dims — restores the vectorized intra-warp
+  layout.
   """
   pid_m = tl.program_id(0)
-  pid_n = tl.program_id(1)
+  pid_n = 0 if SINGLE_N else tl.program_id(1)
   m_off = pid_m * BLOCK_M
   n_off = pid_n * BLOCK_N
 
@@ -138,15 +147,18 @@ def _normalization_vjp_kernel(
     HAS_SCALE: tl.constexpr,
     HAS_OFFSET: tl.constexpr,
     SUBTRACT_MEAN: tl.constexpr,
+    SINGLE_N: tl.constexpr,
 ):
   """Normalization VJP kernel.
 
   2D grid (pid_m, pid_n). Produces per-program partial sums for dscale and
   doffset (shape (grid_m * grid_n, A)), reduced outside the kernel. Operates on
-  the canonical (M, A, N) layout, reducing along the middle axis A.
+  the canonical (M, A, N) layout, reducing along the middle axis A. `SINGLE_N`
+  folds a degenerate N grid id to 0 to keep loads vectorizable (see the forward
+  kernel docstring).
   """
   pid_m = tl.program_id(0)
-  pid_n = tl.program_id(1)
+  pid_n = 0 if SINGLE_N else tl.program_id(1)
   m_off = pid_m * BLOCK_M
   n_off = pid_n * BLOCK_N
 
@@ -272,6 +284,7 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
       alias_kwargs['input_output_aliases'] = {0: 0}
 
     grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
+    single_n = pl.cdiv(N, block_n) == 1
     out_shapes = [
         jax.ShapeDtypeStruct(x_shape, x.dtype),
         jax.ShapeDtypeStruct((num_rows,), jnp.float32),
@@ -299,6 +312,7 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
         SUBTRACT_MEAN=subtract_mean,
         RETURN_MEAN=return_residuals and subtract_mean,
         RETURN_RSTD=return_residuals,
+        SINGLE_N=single_n,
     )
 
     y = y.reshape(orig_x_shape)
@@ -435,6 +449,7 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
         HAS_SCALE=scale is not None,
         HAS_OFFSET=offset is not None,
         SUBTRACT_MEAN=subtract_mean,
+        SINGLE_N=grid_n == 1,
     )
 
     dscale = None

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -15,7 +15,6 @@
 """Native Triton normalization op via jax-triton."""
 
 import dataclasses
-import functools
 from typing import ClassVar, TypeAlias
 
 import jax
@@ -42,32 +41,29 @@ _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
 
 
 def _vmappable(launch):
-  """Adds a `jax.vmap` batching rule to a `jt.triton_call` `launch(*arrays)`.
+  """Adds a `jax.vmap` batching rule that folds the batch into the row dim.
 
-  `jt.triton_call` raises under `vmap` (the batching rule is inherently
+  `jt.triton_call` raises under `vmap` (its batching rule is inherently
   per-kernel, so jax-triton refuses to guess). Normalization batching is just
-  extra rows, so we fold the batch axis with `lax.map`, whose body launches the
-  kernel per slice with no `vmap` tracer. Correct for batched `scale`/`offset`
-  and nested `vmap`. Outside `vmap` this calls `launch` directly (no overhead).
+  extra rows, so we merge each `vmap` axis into the leading batch dimension of
+  every argument and issue a single batch-aware launch.
   """
   f = jax.custom_batching.custom_vmap(launch)
 
   @f.def_vmap
   def _rule(axis_size, in_batched, *arrays):
-    del axis_size
-    idx = [i for i, b in enumerate(in_batched) if b]
-    if not idx:  # Nothing batched (shouldn't happen under `vmap`).
-      return launch(*arrays), in_batched
+    b = axis_size
 
-    def body(slices):
-      full = list(arrays)
-      for i, s in zip(idx, slices):
-        full[i] = s
-      # Call `f` (not `launch`): under nested `vmap` the inner batch axis is
-      # still live here, and must re-enter this rule (→ nested `lax.map`).
-      return f(*full)
+    def merge(a, batched):
+      # Give `a` a leading `b` axis (broadcast if unbatched here), then fold it
+      # into `a`'s existing leading batch dim.
+      if not batched:
+        a = jnp.broadcast_to(a[None], (b, *a.shape))
+      return a.reshape(b * a.shape[1], *a.shape[2:])
 
-    out = jax.lax.map(body, tuple(arrays[i] for i in idx))
+    out = f(*(merge(a, bat) for a, bat in zip(arrays, in_batched)))
+    # Split the folded batch back out for this `vmap` level.
+    out = jax.tree.map(lambda o: o.reshape(b, o.shape[0] // b, *o.shape[1:]), out)
     return out, jax.tree.map(lambda _: True, out)
 
   return f
@@ -94,6 +90,7 @@ def _normalization_kernel(
     RETURN_MEAN: tl.constexpr,
     RETURN_RSTD: tl.constexpr,
     SINGLE_N: tl.constexpr,
+    BATCHED: tl.constexpr,
 ):
   """Normalization forward kernel (layer norm / RMS norm).
 
@@ -108,15 +105,33 @@ def _normalization_kernel(
   vectorization of the reduction axis (scalar, cross-warp layout). Folding it —
   as Pallas/XLA do for size-1 grid dims — restores the vectorized intra-warp
   layout.
+
+  Under `vmap` (`BATCHED`), a batch of B independent normalizations is folded
+  into the grid: the M-grid tiles each batch element separately (grid axis 0 is
+  `B * cdiv(M, BLOCK_M)`), so a block never straddles a batch boundary and
+  `scale`/`offset` can be indexed per batch. `X`/`Y`/`MEAN`/`RSTD`/`SCALE`/
+  `OFFSET` are offset by the program's batch id. When not `BATCHED` this reduces
+  to the single-instance path (`batch == 0`, offsets fold away).
   """
-  pid_m = tl.program_id(0)
+  if BATCHED:
+    grid_m = (M_dim + BLOCK_M - 1) // BLOCK_M
+    pid0 = tl.program_id(0)
+    batch = pid0 // grid_m
+    pid_m = pid0 % grid_m
+    xb = batch * M_dim * stride_m  # X/Y batch stride (M * A * N).
+    sb = batch * M_dim * N_dim  # MEAN/RSTD batch stride (M * N).
+  else:
+    batch = 0
+    pid_m = tl.program_id(0)
+    xb = 0
+    sb = 0
   pid_n = 0 if SINGLE_N else tl.program_id(1)
   m_off = pid_m * BLOCK_M
   n_off = pid_n * BLOCK_N
 
   # (M, A, N) tile: N contiguous (stride 1), A strided by N.
   x_blk = tl.make_block_ptr(
-      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      X + xb, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
       offsets=(m_off, 0, n_off),
       block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   )
@@ -129,7 +144,7 @@ def _normalization_kernel(
     mean = tl.sum(x, axis=1) / A
     if RETURN_MEAN:
       mean_blk = tl.make_block_ptr(
-          MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
+          MEAN + sb, shape=(M_dim, N_dim), strides=(N_dim, 1),
           offsets=(m_off, n_off),
           block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
       )
@@ -142,7 +157,7 @@ def _normalization_kernel(
   rstd = 1.0 / tl.sqrt(var + epsilon)
   if RETURN_RSTD:
     rstd_blk = tl.make_block_ptr(
-        RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
+        RSTD + sb, shape=(M_dim, N_dim), strides=(N_dim, 1),
         offsets=(m_off, n_off),
         block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
     )
@@ -150,14 +165,14 @@ def _normalization_kernel(
   x = x * tl.expand_dims(rstd, 1)
 
   if HAS_SCALE:
-    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    s = tl.load(SCALE + batch * A + a_offs, mask=a_mask, other=0.0).to(tl.float32)
     x = x * (s[None, :, None] + scale_offset)
   if HAS_OFFSET:
-    o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    o = tl.load(OFFSET + batch * A + a_offs, mask=a_mask, other=0.0).to(tl.float32)
     x = x + o[None, :, None]
 
   y_blk = tl.make_block_ptr(
-      Y, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      Y + xb, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
       offsets=(m_off, 0, n_off),
       block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   )
@@ -183,6 +198,7 @@ def _normalization_vjp_kernel(
     HAS_OFFSET: tl.constexpr,
     SUBTRACT_MEAN: tl.constexpr,
     SINGLE_N: tl.constexpr,
+    BATCHED: tl.constexpr,
 ):
   """Normalization VJP kernel.
 
@@ -191,8 +207,27 @@ def _normalization_vjp_kernel(
   the canonical (M, A, N) layout, reducing along the middle axis A. `SINGLE_N`
   folds a degenerate N grid id to 0 to keep loads vectorizable (see the forward
   kernel docstring).
+
+  Under `vmap` (`BATCHED`), B independent normalizations are folded into the
+  M-grid (grid axis 0 is `B * cdiv(M, BLOCK_M)`); each program derives its batch
+  id, offsets its tensors accordingly, indexes `scale` per batch, and writes its
+  dscale/doffset partial into a per-batch slot (partials are (B, grid_m*grid_n,
+  A); the host sums over the programs axis per batch). When not `BATCHED` this
+  reduces to the single-instance path.
   """
-  pid_m = tl.program_id(0)
+  if BATCHED:
+    grid_m = (M_dim + BLOCK_M - 1) // BLOCK_M
+    pid0 = tl.program_id(0)
+    batch = pid0 // grid_m
+    pid_m = pid0 % grid_m
+    xb = batch * M_dim * stride_m  # DOUT/X/DX batch stride (M * A * N).
+    sb = batch * M_dim * N_dim  # MEAN/RSTD batch stride (M * N).
+  else:
+    grid_m = 0  # Unused when not batched.
+    batch = 0
+    pid_m = tl.program_id(0)
+    xb = 0
+    sb = 0
   pid_n = 0 if SINGLE_N else tl.program_id(1)
   m_off = pid_m * BLOCK_M
   n_off = pid_n * BLOCK_N
@@ -202,19 +237,19 @@ def _normalization_vjp_kernel(
 
   # Compute x_norm = (x - mean) * rstd. (M, A, N) tile, N contiguous.
   x_norm = tl.load(tl.make_block_ptr(
-      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      X + xb, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
       offsets=(m_off, 0, n_off),
       block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
   if SUBTRACT_MEAN:
     mean = tl.load(tl.make_block_ptr(
-        MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
+        MEAN + sb, shape=(M_dim, N_dim), strides=(N_dim, 1),
         offsets=(m_off, n_off),
         block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
     ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
     x_norm = x_norm - tl.expand_dims(mean, 1)
   rstd = tl.load(tl.make_block_ptr(
-      RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
+      RSTD + sb, shape=(M_dim, N_dim), strides=(N_dim, 1),
       offsets=(m_off, n_off),
       block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
   ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
@@ -222,14 +257,15 @@ def _normalization_vjp_kernel(
 
   # Load dout tile.
   dout = tl.load(tl.make_block_ptr(
-      DOUT, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      DOUT + xb, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
       offsets=(m_off, 0, n_off),
       block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
 
   # Partial doffset/dscale: reduce (BM, BA, BN) over M and N → (BA,).
-  # Store as (linear_pid, A); host sums axis 0 to get (A,).
-  linear_pid = pid_m * grid_n + pid_n
+  # Store as (batch * grid_m * grid_n + linear_pid, A); host sums the programs
+  # axis per batch to get (B, A).
+  linear_pid = (batch * grid_m + pid_m) * grid_n + pid_n
 
   if HAS_OFFSET:
     doffset = tl.sum(tl.sum(dout, axis=2), axis=0)
@@ -238,7 +274,7 @@ def _normalization_vjp_kernel(
   if HAS_SCALE:
     dscale = tl.sum(tl.sum(dout * x_norm, axis=2), axis=0)
     tl.store(DSCALE + linear_pid * A + a_offs, dscale, mask=a_mask)
-    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    s = tl.load(SCALE + batch * A + a_offs, mask=a_mask, other=0.0).to(tl.float32)
     dout = dout * (s[None, :, None] + scale_offset)
 
   # dx = (dout - mean_a(dout·x_norm)·x_norm [- mean_a(dout)]) * rstd
@@ -251,7 +287,7 @@ def _normalization_vjp_kernel(
   dx = dx * tl.expand_dims(rstd, 1)
 
   tl.store(tl.make_block_ptr(
-      DX, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      DX + xb, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
       offsets=(m_off, 0, n_off),
       block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
   ), dx.to(DX.dtype.element_ty), boundary_check=(0, 1, 2))
@@ -318,38 +354,47 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
     if input_output_alias:
       alias_kwargs['input_output_aliases'] = {0: 0}
 
-    grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
-    single_n = pl.cdiv(N, block_n) == 1
-    out_shapes = [
-        jax.ShapeDtypeStruct(x_shape, x.dtype),
-        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
-        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
-    ]
-    launch = _vmappable(functools.partial(
-        jt.triton_call,
-        kernel=_normalization_kernel,
-        out_shape=out_shapes,
-        grid=grid,
-        num_warps=config.num_warps,
-        **alias_kwargs,
-        M_dim=M,
-        A=A,
-        N_dim=N,
-        stride_m=A * N,
-        stride_a=N,
-        epsilon=epsilon,
-        scale_offset=scale_offset,
-        BLOCK_M=block_m,
-        BLOCK_A=block_a,
-        BLOCK_N=block_n,
-        HAS_SCALE=scale is not None,
-        HAS_OFFSET=offset is not None,
-        SUBTRACT_MEAN=subtract_mean,
-        RETURN_MEAN=return_residuals and subtract_mean,
-        RETURN_RSTD=return_residuals,
-        SINGLE_N=single_n,
-    ))
-    y, mean_flat, rstd_flat = launch(x, scale_arr, offset_arr)
+    grid_m = pl.cdiv(M, block_m)
+    grid_n = pl.cdiv(N, block_n)
+    single_n = grid_n == 1
+
+    # `launch` takes a leading batch dim (folded from `vmap`); grid axis 0 tiles
+    # each batch element separately. See `_vmappable` and the kernel docstring.
+    def launch(x, scale_arr, offset_arr):
+      b = x.shape[0]
+      out_shapes = [
+          jax.ShapeDtypeStruct((b, M, A, N), x.dtype),
+          jax.ShapeDtypeStruct((b, num_rows), jnp.float32),
+          jax.ShapeDtypeStruct((b, num_rows), jnp.float32),
+      ]
+      return jt.triton_call(
+          x, scale_arr, offset_arr,
+          kernel=_normalization_kernel,
+          out_shape=out_shapes,
+          grid=(b * grid_m, grid_n),
+          num_warps=config.num_warps,
+          **alias_kwargs,
+          M_dim=M,
+          A=A,
+          N_dim=N,
+          stride_m=A * N,
+          stride_a=N,
+          epsilon=epsilon,
+          scale_offset=scale_offset,
+          BLOCK_M=block_m,
+          BLOCK_A=block_a,
+          BLOCK_N=block_n,
+          HAS_SCALE=scale is not None,
+          HAS_OFFSET=offset is not None,
+          SUBTRACT_MEAN=subtract_mean,
+          RETURN_MEAN=return_residuals and subtract_mean,
+          RETURN_RSTD=return_residuals,
+          SINGLE_N=single_n,
+          BATCHED=b > 1,
+      )
+
+    y, mean_flat, rstd_flat = _vmappable(launch)(
+        x[None], scale_arr[None], offset_arr[None])
 
     y = y.reshape(orig_x_shape)
 
@@ -456,47 +501,53 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
 
     grid_m = pl.cdiv(M, block_m)
     grid_n = pl.cdiv(N, block_n)
-    grid = (grid_m, grid_n)
     num_programs = grid_m * grid_n
-    dparam_shape = jax.ShapeDtypeStruct((num_programs, A), jnp.float32)
-    dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
-    out_shapes = [
-        jax.ShapeDtypeStruct(x_shape, x.dtype),
-        dparam_shape if scale is not None else dummy_shape,
-        dparam_shape if offset is not None else dummy_shape,
-    ]
-    launch = _vmappable(functools.partial(
-        jt.triton_call,
-        kernel=_normalization_vjp_kernel,
-        out_shape=out_shapes,
-        grid=grid,
-        num_warps=config.num_warps,
-        input_output_aliases={1: 0},
-        M_dim=M,
-        A=A,
-        N_dim=N,
-        stride_m=A * N,
-        stride_a=N,
-        scale_offset=scale_offset,
-        grid_n=grid_n,
-        BLOCK_M=block_m,
-        BLOCK_A=block_a,
-        BLOCK_N=block_n,
-        HAS_SCALE=scale is not None,
-        HAS_OFFSET=offset is not None,
-        SUBTRACT_MEAN=subtract_mean,
-        SINGLE_N=grid_n == 1,
-    ))
-    dx, dscale_partial, doffset_partial = launch(
-        dout, x, scale_arr, mean_flat, rstd_flat)
+
+    # `launch` takes a leading batch dim (folded from `vmap`); dscale/doffset
+    # partials get a per-batch slot, summed over the programs axis below.
+    def launch(dout, x, scale_arr, mean_flat, rstd_flat):
+      b = dout.shape[0]
+      dparam_shape = jax.ShapeDtypeStruct((b, num_programs, A), jnp.float32)
+      dummy_shape = jax.ShapeDtypeStruct((b, 1), jnp.float32)
+      out_shapes = [
+          jax.ShapeDtypeStruct((b, M, A, N), x.dtype),
+          dparam_shape if scale is not None else dummy_shape,
+          dparam_shape if offset is not None else dummy_shape,
+      ]
+      return jt.triton_call(
+          dout, x, scale_arr, mean_flat, rstd_flat,
+          kernel=_normalization_vjp_kernel,
+          out_shape=out_shapes,
+          grid=(b * grid_m, grid_n),
+          num_warps=config.num_warps,
+          input_output_aliases={1: 0},
+          M_dim=M,
+          A=A,
+          N_dim=N,
+          stride_m=A * N,
+          stride_a=N,
+          scale_offset=scale_offset,
+          grid_n=grid_n,
+          BLOCK_M=block_m,
+          BLOCK_A=block_a,
+          BLOCK_N=block_n,
+          HAS_SCALE=scale is not None,
+          HAS_OFFSET=offset is not None,
+          SUBTRACT_MEAN=subtract_mean,
+          SINGLE_N=grid_n == 1,
+          BATCHED=b > 1,
+      )
+
+    dx, dscale_partial, doffset_partial = _vmappable(launch)(
+        dout[None], x[None], scale_arr[None], mean_flat[None], rstd_flat[None])
 
     dscale = None
     if scale is not None:
-      dscale = jnp.sum(dscale_partial, axis=0).astype(scale.dtype)
+      dscale = jnp.sum(dscale_partial.reshape(-1, A), axis=0).astype(scale.dtype)
 
     doffset = None
     if offset is not None:
-      doffset = jnp.sum(doffset_partial, axis=0).astype(offset.dtype)
+      doffset = jnp.sum(doffset_partial.reshape(-1, A), axis=0).astype(offset.dtype)
 
     return (dx.reshape(orig_x_shape), dscale, doffset), None
 

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -44,7 +44,71 @@ _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
 
 
 @triton.jit
-def _normalization_kernel(
+def _normalization_kernel_2d(
+    # --- pointer args: inputs then outputs ---
+    X, SCALE, OFFSET,
+    Y, MEAN, RSTD,
+    # --- scalar args ---
+    M_dim, A, epsilon, scale_offset,
+    # --- constexpr args ---
+    BLOCK_M: tl.constexpr,
+    BLOCK_A: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    HAS_OFFSET: tl.constexpr,
+    SUBTRACT_MEAN: tl.constexpr,
+    RETURN_MEAN: tl.constexpr,
+    RETURN_RSTD: tl.constexpr,
+):
+  """2D normalization forward kernel for the N=1 case (axis=-1).
+
+  1D grid over M. Each program handles a (BLOCK_M, BLOCK_A) tile, reducing
+  along axis 1 (A). Stats are 1D vectors of length M.
+  """
+  pid_m = tl.program_id(0)
+
+  x_blk = tl.make_block_ptr(
+      X, shape=(M_dim, A), strides=(A, 1),
+      offsets=(pid_m * BLOCK_M, 0),
+      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
+  )
+  x = tl.load(x_blk, boundary_check=(0, 1), padding_option='zero').to(tl.float32)
+
+  a_offs = tl.arange(0, BLOCK_A)
+  a_mask = a_offs < A
+  m_off = pid_m * BLOCK_M
+  m_offs = m_off + tl.arange(0, BLOCK_M)
+  m_mask = m_offs < M_dim
+
+  if SUBTRACT_MEAN:
+    mean = tl.sum(x, axis=1) / A
+    if RETURN_MEAN:
+      tl.store(MEAN + m_offs, mean, mask=m_mask)
+    x = x - mean[:, None]
+    x = tl.where(a_mask[None, :], x, 0.0)
+
+  var = tl.sum(x * x, axis=1) / A
+  rstd = 1.0 / tl.sqrt(var + epsilon)
+  if RETURN_RSTD:
+    tl.store(RSTD + m_offs, rstd, mask=m_mask)
+  x = x * rstd[:, None]
+
+  if HAS_SCALE:
+    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    x = x * (s[None, :] + scale_offset)
+  if HAS_OFFSET:
+    o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    x = x + o[None, :]
+
+  y_blk = tl.make_block_ptr(
+      Y, shape=(M_dim, A), strides=(A, 1),
+      offsets=(pid_m * BLOCK_M, 0),
+      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
+  )
+  tl.store(y_blk, x.to(Y.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit
+def _normalization_kernel_3d(
     # --- pointer args: inputs then outputs ---
     X, SCALE, OFFSET,
     Y, MEAN, RSTD,
@@ -60,7 +124,7 @@ def _normalization_kernel(
     RETURN_MEAN: tl.constexpr,
     RETURN_RSTD: tl.constexpr,
 ):
-  """Normalization forward kernel (layer norm / RMS norm).
+  """3D normalization forward kernel for the general case.
 
   Operates on a canonicalized (M, A, N) layout where A is the norm axis.
   2D grid (pid_m, pid_n) tiles over M and N; each program reduces a full
@@ -69,29 +133,30 @@ def _normalization_kernel(
   pid_m = tl.program_id(0)
   pid_n = tl.program_id(1)
 
-  m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+  # Block pointers for the 3D x/y tile.
+  x_blk = tl.make_block_ptr(
+      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(pid_m * BLOCK_M, 0, pid_n * BLOCK_N),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+  )
+  x = tl.load(x_blk, boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
+
   a_offs = tl.arange(0, BLOCK_A)
-  n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-
-  m_mask = m_offs < M_dim
   a_mask = a_offs < A
-  n_mask = n_offs < N_dim
-  mask = m_mask[:, None, None] & a_mask[None, :, None] & n_mask[None, None, :]
 
-  # Load x tile: (BLOCK_M, BLOCK_A, BLOCK_N).
-  x_ptrs = (X + m_offs[:, None, None] * stride_m
-            + a_offs[None, :, None] * stride_a
-            + n_offs[None, None, :])
-  x = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
-
-  # Stats are (BLOCK_M, BLOCK_N) — one value per (m, n) instance.
-  stat_mask = m_mask[:, None] & n_mask[None, :]
-  stat_ptrs = m_offs[:, None] * N_dim + n_offs[None, :]
+  # Stat offsets for block pointers.
+  stat_m_off = pid_m * BLOCK_M
+  stat_n_off = pid_n * BLOCK_N
 
   if SUBTRACT_MEAN:
     mean = tl.sum(x, axis=1) / A
     if RETURN_MEAN:
-      tl.store(MEAN + stat_ptrs, mean, mask=stat_mask)
+      mean_blk = tl.make_block_ptr(
+          MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
+          offsets=(stat_m_off, stat_n_off),
+          block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
+      )
+      tl.store(mean_blk, mean, boundary_check=(0, 1))
     x = x - tl.expand_dims(mean, 1)
     # Zero invalid values (when A is not a power of two).
     x = tl.where(a_mask[None, :, None], x, 0.0)
@@ -99,7 +164,12 @@ def _normalization_kernel(
   var = tl.sum(x * x, axis=1) / A
   rstd = 1.0 / tl.sqrt(var + epsilon)
   if RETURN_RSTD:
-    tl.store(RSTD + stat_ptrs, rstd, mask=stat_mask)
+    rstd_blk = tl.make_block_ptr(
+        RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
+        offsets=(stat_m_off, stat_n_off),
+        block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
+    )
+    tl.store(rstd_blk, rstd, boundary_check=(0, 1))
   x = x * tl.expand_dims(rstd, 1)
 
   if HAS_SCALE:
@@ -109,13 +179,79 @@ def _normalization_kernel(
     o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
     x = x + o[None, :, None]
 
-  y_ptrs = (Y + m_offs[:, None, None] * stride_m
-            + a_offs[None, :, None] * stride_a
-            + n_offs[None, None, :])
-  tl.store(y_ptrs, x, mask=mask)
+  y_blk = tl.make_block_ptr(
+      Y, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(pid_m * BLOCK_M, 0, pid_n * BLOCK_N),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+  )
+  tl.store(y_blk, x.to(Y.dtype.element_ty), boundary_check=(0, 1, 2))
 
 
 # ── VJP kernel ──────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _normalization_vjp_kernel_2d(
+    # --- pointer args: inputs then outputs ---
+    DOUT, X, SCALE, MEAN, RSTD,
+    DX, DSCALE, DOFFSET,
+    # --- scalar args ---
+    M_dim, A, scale_offset,
+    # --- constexpr args ---
+    BLOCK_M: tl.constexpr,
+    BLOCK_A: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    HAS_OFFSET: tl.constexpr,
+    SUBTRACT_MEAN: tl.constexpr,
+):
+  """2D normalization VJP kernel for the N=1 case."""
+  pid_m = tl.program_id(0)
+  m_off = pid_m * BLOCK_M
+
+  a_offs = tl.arange(0, BLOCK_A)
+  a_mask = a_offs < A
+  m_offs = m_off + tl.arange(0, BLOCK_M)
+  m_mask = m_offs < M_dim
+
+  x_norm = tl.load(tl.make_block_ptr(
+      X, shape=(M_dim, A), strides=(A, 1),
+      offsets=(m_off, 0),
+      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
+  ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
+  if SUBTRACT_MEAN:
+    mean = tl.load(MEAN + m_offs, mask=m_mask, other=0.0).to(tl.float32)
+    x_norm = x_norm - mean[:, None]
+  rstd = tl.load(RSTD + m_offs, mask=m_mask, other=0.0).to(tl.float32)
+  x_norm = x_norm * rstd[:, None]
+
+  dout = tl.load(tl.make_block_ptr(
+      DOUT, shape=(M_dim, A), strides=(A, 1),
+      offsets=(m_off, 0),
+      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
+  ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
+
+  if HAS_OFFSET:
+    doffset = tl.sum(dout, axis=0)
+    tl.store(DOFFSET + pid_m * A + a_offs, doffset, mask=a_mask)
+
+  if HAS_SCALE:
+    dscale = tl.sum(dout * x_norm, axis=0)
+    tl.store(DSCALE + pid_m * A + a_offs, dscale, mask=a_mask)
+    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    dout = dout * (s[None, :] + scale_offset)
+
+  dx1 = -(tl.sum(dout * x_norm, axis=1) / A)
+  dx = dout + dx1[:, None] * x_norm
+  if SUBTRACT_MEAN:
+    dx2 = -(tl.sum(dout, axis=1) / A)
+    dx = dx + dx2[:, None]
+  dx = dx * rstd[:, None]
+
+  tl.store(tl.make_block_ptr(
+      DX, shape=(M_dim, A), strides=(A, 1),
+      offsets=(m_off, 0),
+      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
+  ), dx.to(DX.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.jit
@@ -140,33 +276,38 @@ def _normalization_vjp_kernel(
   """
   pid_m = tl.program_id(0)
   pid_n = tl.program_id(1)
+  tile_m_off = pid_m * BLOCK_M
+  tile_n_off = pid_n * BLOCK_N
 
-  m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
   a_offs = tl.arange(0, BLOCK_A)
-  n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-
-  m_mask = m_offs < M_dim
   a_mask = a_offs < A
-  n_mask = n_offs < N_dim
-  mask = m_mask[:, None, None] & a_mask[None, :, None] & n_mask[None, None, :]
-
-  # Shared pointer offsets for the 3D tile.
-  tile_ptrs = (m_offs[:, None, None] * stride_m
-               + a_offs[None, :, None] * stride_a
-               + n_offs[None, None, :])
 
   # Compute x_norm = (x - mean) * rstd.
-  x_norm = tl.load(X + tile_ptrs, mask=mask, other=0.0).to(tl.float32)
-  stat_mask = m_mask[:, None] & n_mask[None, :]
-  stat_ptrs = m_offs[:, None] * N_dim + n_offs[None, :]
+  x_norm = tl.load(tl.make_block_ptr(
+      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(tile_m_off, 0, tile_n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+  ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
   if SUBTRACT_MEAN:
-    mean = tl.load(MEAN + stat_ptrs, mask=stat_mask, other=0.0).to(tl.float32)
+    mean = tl.load(tl.make_block_ptr(
+        MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
+        offsets=(tile_m_off, tile_n_off),
+        block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
+    ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
     x_norm = x_norm - tl.expand_dims(mean, 1)
-  rstd = tl.load(RSTD + stat_ptrs, mask=stat_mask, other=0.0).to(tl.float32)
+  rstd = tl.load(tl.make_block_ptr(
+      RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
+      offsets=(tile_m_off, tile_n_off),
+      block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
+  ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
   x_norm = x_norm * tl.expand_dims(rstd, 1)
 
   # Load dout tile.
-  dout = tl.load(DOUT + tile_ptrs, mask=mask, other=0.0).to(tl.float32)
+  dout = tl.load(tl.make_block_ptr(
+      DOUT, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(tile_m_off, 0, tile_n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+  ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
 
   # Partial doffset/dscale: reduce (BM, BA, BN) → (BA,) via two sum axes.
   # Store as (linear_pid, A); host sums axis 0 to get (A,).
@@ -191,7 +332,11 @@ def _normalization_vjp_kernel(
     dx = dx + dx2
   dx = dx * tl.expand_dims(rstd, 1)
 
-  tl.store(DX + tile_ptrs, dx, mask=mask)
+  tl.store(tl.make_block_ptr(
+      DX, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
+      offsets=(tile_m_off, 0, tile_n_off),
+      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+  ), dx.to(DX.dtype.element_ty), boundary_check=(0, 1, 2))
 
 
 # ── Forward op ──────────────────────────────────────────────────────────────────
@@ -251,40 +396,68 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
     scale_arr = scale if scale is not None else dummy
     offset_arr = offset if offset is not None else dummy
 
-    grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
-    out_shapes = [
-        jax.ShapeDtypeStruct(x_shape, x.dtype),
-        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
-        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
-    ]
-
     alias_kwargs = {}
     if input_output_alias:
       alias_kwargs['input_output_aliases'] = {0: 0}
 
-    y, mean_flat, rstd_flat = jt.triton_call(
-        x, scale_arr, offset_arr,
-        kernel=_normalization_kernel,
-        out_shape=out_shapes,
-        grid=grid,
-        num_warps=config.num_warps,
-        **alias_kwargs,
-        M_dim=M,
-        A=A,
-        N_dim=N,
-        stride_m=A * N,
-        stride_a=N,
-        epsilon=epsilon,
-        scale_offset=scale_offset,
-        BLOCK_M=block_m,
-        BLOCK_A=block_a,
-        BLOCK_N=block_n,
-        HAS_SCALE=scale is not None,
-        HAS_OFFSET=offset is not None,
-        SUBTRACT_MEAN=subtract_mean,
-        RETURN_MEAN=return_residuals and subtract_mean,
-        RETURN_RSTD=return_residuals,
-    )
+    if N == 1:
+      # 2D fast path: (M, A) layout, 1D grid, no N dimension overhead.
+      x = x.reshape(M, A)
+      out_shapes = [
+          jax.ShapeDtypeStruct((M, A), x.dtype),
+          jax.ShapeDtypeStruct((M,), jnp.float32),
+          jax.ShapeDtypeStruct((M,), jnp.float32),
+      ]
+      y, mean_flat, rstd_flat = jt.triton_call(
+          x, scale_arr, offset_arr,
+          kernel=_normalization_kernel_2d,
+          out_shape=out_shapes,
+          grid=(pl.cdiv(M, block_m),),
+          num_warps=config.num_warps,
+          **alias_kwargs,
+          M_dim=M,
+          A=A,
+          epsilon=epsilon,
+          scale_offset=scale_offset,
+          BLOCK_M=block_m,
+          BLOCK_A=block_a,
+          HAS_SCALE=scale is not None,
+          HAS_OFFSET=offset is not None,
+          SUBTRACT_MEAN=subtract_mean,
+          RETURN_MEAN=return_residuals and subtract_mean,
+          RETURN_RSTD=return_residuals,
+      )
+    else:
+      # 3D general path.
+      grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
+      out_shapes = [
+          jax.ShapeDtypeStruct(x_shape, x.dtype),
+          jax.ShapeDtypeStruct((num_rows,), jnp.float32),
+          jax.ShapeDtypeStruct((num_rows,), jnp.float32),
+      ]
+      y, mean_flat, rstd_flat = jt.triton_call(
+          x, scale_arr, offset_arr,
+          kernel=_normalization_kernel_3d,
+          out_shape=out_shapes,
+          grid=grid,
+          num_warps=config.num_warps,
+          **alias_kwargs,
+          M_dim=M,
+          A=A,
+          N_dim=N,
+          stride_m=A * N,
+          stride_a=N,
+          epsilon=epsilon,
+          scale_offset=scale_offset,
+          BLOCK_M=block_m,
+          BLOCK_A=block_a,
+          BLOCK_N=block_n,
+          HAS_SCALE=scale is not None,
+          HAS_OFFSET=offset is not None,
+          SUBTRACT_MEAN=subtract_mean,
+          RETURN_MEAN=return_residuals and subtract_mean,
+          RETURN_RSTD=return_residuals,
+      )
 
     y = y.reshape(orig_x_shape)
 
@@ -379,7 +552,7 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
     block_m = config.block_m
     block_n = 1 if config.block_n is None else config.block_n
 
-    # Flatten stats to (M*N,) — same layout the forward kernel wrote.
+    # Flatten stats — same layout the forward kernel wrote.
     mean_flat = (
         mean.reshape(-1) if mean is not None
         else jnp.zeros(1, dtype=jnp.float32)
@@ -390,41 +563,67 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
     scale_arr = scale if scale is not None else dummy
 
     grid_m = pl.cdiv(M, block_m)
-    grid_n = pl.cdiv(N, block_n)
-    grid = (grid_m, grid_n)
-    num_programs = grid_m * grid_n
 
-    # dx always needed; dscale/doffset only when scale/offset present.
-    # Partial sums are (num_programs, A), reduced to (A,) after the kernel.
-    dparam_shape = jax.ShapeDtypeStruct((num_programs, A), jnp.float32)
-    dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
-    out_shapes = [
-        jax.ShapeDtypeStruct(x_shape, x.dtype),
-        dparam_shape if scale is not None else dummy_shape,
-        dparam_shape if offset is not None else dummy_shape,
-    ]
-
-    dx, dscale_partial, doffset_partial = jt.triton_call(
-        dout, x, scale_arr, mean_flat, rstd_flat,
-        kernel=_normalization_vjp_kernel,
-        out_shape=out_shapes,
-        grid=grid,
-        num_warps=config.num_warps,
-        input_output_aliases={1: 0},  # x buffer reused for dx
-        M_dim=M,
-        A=A,
-        N_dim=N,
-        stride_m=A * N,
-        stride_a=N,
-        scale_offset=scale_offset,
-        grid_n=grid_n,
-        BLOCK_M=block_m,
-        BLOCK_A=block_a,
-        BLOCK_N=block_n,
-        HAS_SCALE=scale is not None,
-        HAS_OFFSET=offset is not None,
-        SUBTRACT_MEAN=subtract_mean,
-    )
+    if N == 1:
+      # 2D fast path.
+      x = x.reshape(M, A)
+      dout = dout.reshape(M, A)
+      dparam_shape = jax.ShapeDtypeStruct((grid_m, A), jnp.float32)
+      dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
+      out_shapes = [
+          jax.ShapeDtypeStruct((M, A), x.dtype),
+          dparam_shape if scale is not None else dummy_shape,
+          dparam_shape if offset is not None else dummy_shape,
+      ]
+      dx, dscale_partial, doffset_partial = jt.triton_call(
+          dout, x, scale_arr, mean_flat, rstd_flat,
+          kernel=_normalization_vjp_kernel_2d,
+          out_shape=out_shapes,
+          grid=(grid_m,),
+          num_warps=config.num_warps,
+          input_output_aliases={1: 0},
+          M_dim=M,
+          A=A,
+          scale_offset=scale_offset,
+          BLOCK_M=block_m,
+          BLOCK_A=block_a,
+          HAS_SCALE=scale is not None,
+          HAS_OFFSET=offset is not None,
+          SUBTRACT_MEAN=subtract_mean,
+      )
+    else:
+      # 3D general path.
+      grid_n = pl.cdiv(N, block_n)
+      grid = (grid_m, grid_n)
+      num_programs = grid_m * grid_n
+      dparam_shape = jax.ShapeDtypeStruct((num_programs, A), jnp.float32)
+      dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
+      out_shapes = [
+          jax.ShapeDtypeStruct(x_shape, x.dtype),
+          dparam_shape if scale is not None else dummy_shape,
+          dparam_shape if offset is not None else dummy_shape,
+      ]
+      dx, dscale_partial, doffset_partial = jt.triton_call(
+          dout, x, scale_arr, mean_flat, rstd_flat,
+          kernel=_normalization_vjp_kernel,
+          out_shape=out_shapes,
+          grid=grid,
+          num_warps=config.num_warps,
+          input_output_aliases={1: 0},
+          M_dim=M,
+          A=A,
+          N_dim=N,
+          stride_m=A * N,
+          stride_a=N,
+          scale_offset=scale_offset,
+          grid_n=grid_n,
+          BLOCK_M=block_m,
+          BLOCK_A=block_a,
+          BLOCK_N=block_n,
+          HAS_SCALE=scale is not None,
+          HAS_OFFSET=offset is not None,
+          SUBTRACT_MEAN=subtract_mean,
+      )
 
     dscale = None
     if scale is not None:

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -26,15 +26,15 @@ import triton.language as tl
 from tokamax._src import gpu_utils
 from tokamax._src.ops import op
 from tokamax._src.ops.normalization import base
-from tokamax._src.ops.normalization import pallas_triton_config
-from tokamax._src.ops.normalization import pallas_triton_vjp_config
+from tokamax._src.ops.normalization import triton_config
+from tokamax._src.ops.normalization import triton_vjp_config
 from typing_extensions import override
 
 
-Config: TypeAlias = pallas_triton_config.Config
-Key: TypeAlias = pallas_triton_config.Key
-VjpConfig: TypeAlias = pallas_triton_vjp_config.Config
-VjpKey: TypeAlias = pallas_triton_vjp_config.Key
+Config: TypeAlias = triton_config.Config
+Key: TypeAlias = triton_config.Key
+VjpConfig: TypeAlias = triton_vjp_config.Config
+VjpKey: TypeAlias = triton_vjp_config.Key
 FusedInputArray = base.FusedInputArray
 Residuals = base.Residuals
 _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
@@ -268,7 +268,7 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
       x = x()
 
     orig_x_shape = x.shape
-    x_shape = pallas_triton_config.canonicalize_shape_3d(orig_x_shape, axis)
+    x_shape = triton_config.canonicalize_shape_3d(orig_x_shape, axis)
     x = x.reshape(x_shape)
     M, A, N = x_shape
     num_rows = M * N
@@ -330,19 +330,19 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
 
   @override
   def _get_heuristics_config(self, ba: op.BoundArguments) -> Config:
-    return pallas_triton_config.get_heuristics_config(
+    return triton_config.get_heuristics_config(
         *ba.args, vmap_axis_sizes=ba.vmap_axis_sizes, **ba.kwargs
     )
 
   @override
   def _get_autotuning_cache_key(self, ba: op.BoundArguments) -> Key:
-    return pallas_triton_config.get_key(*ba.args, **ba.kwargs)
+    return triton_config.get_key(*ba.args, **ba.kwargs)
 
   @override
   def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[Config]:
     x = ba.args[0]
     axis = ba.kwargs['axis']
-    x_shape = pallas_triton_config.canonicalize_shape(x.shape, axis)
+    x_shape = triton_config.canonicalize_shape(x.shape, axis)
     configs = set()
     for num_warps in [1, 2, 4, 8, 16]:
       for block_m in [1, 2, 4, 8, 16, 32, 64]:
@@ -402,7 +402,7 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
       raise ValueError('`mean` residual inconsistent with `subtract_mean`.')
 
     orig_x_shape = x.shape
-    x_shape = pallas_triton_config.canonicalize_shape_3d(x.shape, axis)
+    x_shape = triton_config.canonicalize_shape_3d(x.shape, axis)
     x = x.reshape(x_shape)
     dout = dout.reshape(x_shape)
     M, A, N = x_shape
@@ -466,18 +466,18 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
 
   @override
   def _get_heuristics_config(self, ba: op.BoundArguments) -> VjpConfig:
-    return pallas_triton_vjp_config.get_heuristics_config(
+    return triton_vjp_config.get_heuristics_config(
         *ba.args, vmap_axis_sizes=ba.vmap_axis_sizes, **ba.kwargs
     )
 
   @override
   def _get_autotuning_cache_key(self, ba: op.BoundArguments) -> VjpKey:
-    return pallas_triton_vjp_config.get_key(*ba.args, **ba.kwargs)
+    return triton_vjp_config.get_key(*ba.args, **ba.kwargs)
 
   @override
   def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[VjpConfig]:
     axis = ba.kwargs['axis']
-    dout_shape = pallas_triton_config.canonicalize_shape(ba.args[2].shape, axis)
+    dout_shape = triton_config.canonicalize_shape(ba.args[2].shape, axis)
     configs = set()
     for num_warps in [1, 2, 4, 8, 16]:
       for block_m in [1, 2, 4, 8, 16, 32, 64, 128]:

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -1,0 +1,471 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Native Triton normalization op via jax-triton."""
+
+import dataclasses
+from typing import ClassVar, TypeAlias
+
+import jax
+from jax.experimental import pallas as pl
+import jax.numpy as jnp
+import jax_triton as jt
+import triton
+import triton.language as tl
+from tokamax._src import gpu_utils
+from tokamax._src.ops import op
+from tokamax._src.ops.normalization import base
+from tokamax._src.ops.normalization import pallas_triton_config
+from tokamax._src.ops.normalization import pallas_triton_vjp_config
+from typing_extensions import override
+
+
+Config: TypeAlias = pallas_triton_config.Config
+Key: TypeAlias = pallas_triton_config.Key
+VjpConfig: TypeAlias = pallas_triton_vjp_config.Config
+VjpKey: TypeAlias = pallas_triton_vjp_config.Key
+FusedInputArray = base.FusedInputArray
+Residuals = base.Residuals
+_NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
+
+
+# ── Forward kernel ─────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _normalization_kernel(
+    # --- pointer args: inputs then outputs ---
+    X, SCALE, OFFSET,
+    Y, MEAN, RSTD,
+    # --- scalar args ---
+    M_dim, A, N_dim, stride_m, stride_a, epsilon, scale_offset,
+    # --- constexpr args ---
+    BLOCK_M: tl.constexpr,
+    BLOCK_A: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    HAS_OFFSET: tl.constexpr,
+    SUBTRACT_MEAN: tl.constexpr,
+    RETURN_MEAN: tl.constexpr,
+    RETURN_RSTD: tl.constexpr,
+):
+  """Normalization forward kernel (layer norm / RMS norm).
+
+  Operates on a canonicalized (M, A, N) layout where A is the norm axis.
+  2D grid (pid_m, pid_n) tiles over M and N; each program reduces a full
+  (BLOCK_M, A, BLOCK_N) tile along A.
+  """
+  pid_m = tl.program_id(0)
+  pid_n = tl.program_id(1)
+
+  m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+  a_offs = tl.arange(0, BLOCK_A)
+  n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+  m_mask = m_offs < M_dim
+  a_mask = a_offs < A
+  n_mask = n_offs < N_dim
+  mask = m_mask[:, None, None] & a_mask[None, :, None] & n_mask[None, None, :]
+
+  # Load x tile: (BLOCK_M, BLOCK_A, BLOCK_N).
+  x_ptrs = (X + m_offs[:, None, None] * stride_m
+            + a_offs[None, :, None] * stride_a
+            + n_offs[None, None, :])
+  x = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
+
+  # Stats are (BLOCK_M, BLOCK_N) — one value per (m, n) instance.
+  stat_mask = m_mask[:, None] & n_mask[None, :]
+  stat_ptrs = m_offs[:, None] * N_dim + n_offs[None, :]
+
+  if SUBTRACT_MEAN:
+    mean = tl.sum(x, axis=1) / A
+    if RETURN_MEAN:
+      tl.store(MEAN + stat_ptrs, mean, mask=stat_mask)
+    x = x - tl.expand_dims(mean, 1)
+    # Zero invalid values (when A is not a power of two).
+    x = tl.where(a_mask[None, :, None], x, 0.0)
+
+  var = tl.sum(x * x, axis=1) / A
+  rstd = 1.0 / tl.sqrt(var + epsilon)
+  if RETURN_RSTD:
+    tl.store(RSTD + stat_ptrs, rstd, mask=stat_mask)
+  x = x * tl.expand_dims(rstd, 1)
+
+  if HAS_SCALE:
+    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    x = x * (s[None, :, None] + scale_offset)
+  if HAS_OFFSET:
+    o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    x = x + o[None, :, None]
+
+  y_ptrs = (Y + m_offs[:, None, None] * stride_m
+            + a_offs[None, :, None] * stride_a
+            + n_offs[None, None, :])
+  tl.store(y_ptrs, x, mask=mask)
+
+
+# ── VJP kernel ──────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _normalization_vjp_kernel(
+    # --- pointer args: inputs then outputs ---
+    DOUT, X, SCALE, MEAN, RSTD,
+    DX, DSCALE, DOFFSET,
+    # --- scalar args ---
+    M_dim, A, N_dim, stride_m, stride_a, scale_offset, grid_n,
+    # --- constexpr args ---
+    BLOCK_M: tl.constexpr,
+    BLOCK_A: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    HAS_OFFSET: tl.constexpr,
+    SUBTRACT_MEAN: tl.constexpr,
+):
+  """Normalization VJP kernel.
+
+  2D grid (pid_m, pid_n). Produces per-program partial sums for dscale and
+  doffset (shape (grid_m * grid_n, A)), reduced outside the kernel.
+  """
+  pid_m = tl.program_id(0)
+  pid_n = tl.program_id(1)
+
+  m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+  a_offs = tl.arange(0, BLOCK_A)
+  n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+  m_mask = m_offs < M_dim
+  a_mask = a_offs < A
+  n_mask = n_offs < N_dim
+  mask = m_mask[:, None, None] & a_mask[None, :, None] & n_mask[None, None, :]
+
+  # Shared pointer offsets for the 3D tile.
+  tile_ptrs = (m_offs[:, None, None] * stride_m
+               + a_offs[None, :, None] * stride_a
+               + n_offs[None, None, :])
+
+  # Compute x_norm = (x - mean) * rstd.
+  x_norm = tl.load(X + tile_ptrs, mask=mask, other=0.0).to(tl.float32)
+  stat_mask = m_mask[:, None] & n_mask[None, :]
+  stat_ptrs = m_offs[:, None] * N_dim + n_offs[None, :]
+  if SUBTRACT_MEAN:
+    mean = tl.load(MEAN + stat_ptrs, mask=stat_mask, other=0.0).to(tl.float32)
+    x_norm = x_norm - tl.expand_dims(mean, 1)
+  rstd = tl.load(RSTD + stat_ptrs, mask=stat_mask, other=0.0).to(tl.float32)
+  x_norm = x_norm * tl.expand_dims(rstd, 1)
+
+  # Load dout tile.
+  dout = tl.load(DOUT + tile_ptrs, mask=mask, other=0.0).to(tl.float32)
+
+  # Partial doffset/dscale: reduce (BM, BA, BN) → (BA,) via two sum axes.
+  # Store as (linear_pid, A); host sums axis 0 to get (A,).
+  linear_pid = pid_m * grid_n + pid_n
+
+  if HAS_OFFSET:
+    doffset = tl.sum(tl.sum(dout, axis=2), axis=0)
+    tl.store(DOFFSET + linear_pid * A + a_offs, doffset, mask=a_mask)
+
+  if HAS_SCALE:
+    dscale = tl.sum(tl.sum(dout * x_norm, axis=2), axis=0)
+    tl.store(DSCALE + linear_pid * A + a_offs, dscale, mask=a_mask)
+    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+    dout = dout * (s[None, :, None] + scale_offset)
+
+  # dx = (dout - mean_a(dout·x_norm)·x_norm [- mean_a(dout)]) * rstd
+  # Reductions over axis 1 (the A dimension).
+  dx1 = tl.expand_dims(-(tl.sum(dout * x_norm, axis=1) / A), 1)
+  dx = dout + dx1 * x_norm
+  if SUBTRACT_MEAN:
+    dx2 = tl.expand_dims(-(tl.sum(dout, axis=1) / A), 1)
+    dx = dx + dx2
+  dx = dx * tl.expand_dims(rstd, 1)
+
+  tl.store(DX + tile_ptrs, dx, mask=mask)
+
+
+# ── Forward op ──────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class JaxTritonNormalization(base.Normalization[Config, Key]):
+  """Native Triton normalization op via jax-triton."""
+
+  config_cls: ClassVar[type[Config]] = Config
+  supports_symbolic_shapes: ClassVar[bool] = False
+  # If `None`, `input_output_alias = not return_residuals`.
+  input_output_alias: bool | None = None
+
+  def __post_init__(self):
+    if self.vjp is None:
+      vjp = JaxTritonNormalizationVjp()
+      object.__setattr__(self, 'vjp', vjp)
+
+  @override
+  def _fwd(
+      self,
+      x: jax.Array | FusedInputArray,
+      scale: jax.Array | None,
+      offset: jax.Array | None,
+      *,
+      axis: int,
+      epsilon: float,
+      scale_offset: float,
+      subtract_mean: bool,
+      return_residuals: bool,
+      config: Config,
+  ) -> tuple[jax.Array, base.Residuals | None]:
+    input_output_alias = self.input_output_alias
+    if input_output_alias is None:
+      input_output_alias = not return_residuals and not callable(x)
+    elif input_output_alias and callable(x):
+      raise NotImplementedError(
+          '`input_output_alias` not supported when `x` is a callable.'
+      )
+
+    # Materialize fused inputs — no Pallas fusion support in native Triton.
+    if callable(x):
+      x = x()
+
+    orig_x_shape = x.shape
+    x_shape = pallas_triton_config.canonicalize_shape_3d(orig_x_shape, axis)
+    x = x.reshape(x_shape)
+    M, A, N = x_shape
+    num_rows = M * N
+    block_a = pl.next_power_of_2(A)
+    block_m = config.block_m
+    block_n = 1 if config.block_n is None else config.block_n
+
+    # Dummy arrays for optional inputs (never dereferenced by the kernel).
+    dummy = jnp.zeros(1, dtype=x.dtype)
+    scale_arr = scale if scale is not None else dummy
+    offset_arr = offset if offset is not None else dummy
+
+    grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
+    out_shapes = [
+        jax.ShapeDtypeStruct(x_shape, x.dtype),
+        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
+        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
+    ]
+
+    alias_kwargs = {}
+    if input_output_alias:
+      alias_kwargs['input_output_aliases'] = {0: 0}
+
+    y, mean_flat, rstd_flat = jt.triton_call(
+        x, scale_arr, offset_arr,
+        kernel=_normalization_kernel,
+        out_shape=out_shapes,
+        grid=grid,
+        num_warps=config.num_warps,
+        **alias_kwargs,
+        M_dim=M,
+        A=A,
+        N_dim=N,
+        stride_m=A * N,
+        stride_a=N,
+        epsilon=epsilon,
+        scale_offset=scale_offset,
+        BLOCK_M=block_m,
+        BLOCK_A=block_a,
+        BLOCK_N=block_n,
+        HAS_SCALE=scale is not None,
+        HAS_OFFSET=offset is not None,
+        SUBTRACT_MEAN=subtract_mean,
+        RETURN_MEAN=return_residuals and subtract_mean,
+        RETURN_RSTD=return_residuals,
+    )
+
+    y = y.reshape(orig_x_shape)
+
+    if return_residuals:
+      stat_shape = list(orig_x_shape)
+      stat_shape[axis] = 1
+      rstd = rstd_flat.reshape(stat_shape)
+      mean = mean_flat.reshape(stat_shape) if subtract_mean else None
+      return y, (mean, rstd)
+
+    return y, None
+
+  @override
+  def _get_heuristics_config(self, ba: op.BoundArguments) -> Config:
+    return pallas_triton_config.get_heuristics_config(
+        *ba.args, vmap_axis_sizes=ba.vmap_axis_sizes, **ba.kwargs
+    )
+
+  @override
+  def _get_autotuning_cache_key(self, ba: op.BoundArguments) -> Key:
+    return pallas_triton_config.get_key(*ba.args, **ba.kwargs)
+
+  @override
+  def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[Config]:
+    x = ba.args[0]
+    axis = ba.kwargs['axis']
+    x_shape = pallas_triton_config.canonicalize_shape(x.shape, axis)
+    configs = set()
+    for num_warps in [1, 2, 4, 8, 16]:
+      for block_m in [1, 2, 4, 8, 16, 32, 64]:
+        block_m = min(block_m, pl.next_power_of_2(x_shape[0]))
+        if len(x_shape) > 2:
+          for block_n in [16, 32, 64, 128]:
+            block_n = min(block_n, pl.next_power_of_2(x_shape[2]))
+            if (block_m * x_shape[1] * block_n <= _NUM_REGISTERS_PER_SM) or (
+                block_m == 1 and block_n <= 16
+            ):
+              configs.add(
+                  Config(block_m=block_m, block_n=block_n, num_warps=num_warps)
+              )
+        elif block_m * x_shape[1] <= _NUM_REGISTERS_PER_SM or block_m == 1:
+          configs.add(Config(block_m=block_m, block_n=None, num_warps=num_warps))
+    return configs
+
+  @override
+  def supported_on(self, device: jax.Device) -> bool:
+    return gpu_utils.has_triton_support(device)
+
+
+# ── VJP op ──────────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
+  """Native Triton normalization VJP via jax-triton."""
+
+  config_cls: ClassVar[type[VjpConfig]] = VjpConfig
+
+  @override
+  def _fwd(
+      self,
+      residuals: Residuals,
+      out: jax.Array,
+      dout: jax.Array,
+      x: jax.Array,
+      scale: jax.Array | None,
+      offset: jax.Array | None,
+      *,
+      axis: int,
+      epsilon: float,
+      scale_offset: float,
+      subtract_mean: bool,
+      return_residuals: bool,
+      config: VjpConfig,
+  ) -> tuple[tuple[jax.Array, jax.Array | None, jax.Array | None], None]:
+    """Computes normalization VJP `(dx, dscale, doffset)`."""
+    del out, epsilon  # Unused.
+
+    if return_residuals:
+      raise NotImplementedError('`return_residuals` not supported.')
+
+    mean, rstddev = residuals
+    if (mean is not None) != subtract_mean:
+      raise ValueError('`mean` residual inconsistent with `subtract_mean`.')
+
+    orig_x_shape = x.shape
+    x_shape = pallas_triton_config.canonicalize_shape_3d(x.shape, axis)
+    x = x.reshape(x_shape)
+    dout = dout.reshape(x_shape)
+    M, A, N = x_shape
+    block_a = pl.next_power_of_2(A)
+    block_m = config.block_m
+    block_n = 1 if config.block_n is None else config.block_n
+
+    # Flatten stats to (M*N,) — same layout the forward kernel wrote.
+    mean_flat = (
+        mean.reshape(-1) if mean is not None
+        else jnp.zeros(1, dtype=jnp.float32)
+    )
+    rstd_flat = rstddev.reshape(-1)
+
+    dummy = jnp.zeros(1, dtype=x.dtype)
+    scale_arr = scale if scale is not None else dummy
+
+    grid_m = pl.cdiv(M, block_m)
+    grid_n = pl.cdiv(N, block_n)
+    grid = (grid_m, grid_n)
+    num_programs = grid_m * grid_n
+
+    # dx always needed; dscale/doffset only when scale/offset present.
+    # Partial sums are (num_programs, A), reduced to (A,) after the kernel.
+    dparam_shape = jax.ShapeDtypeStruct((num_programs, A), jnp.float32)
+    dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
+    out_shapes = [
+        jax.ShapeDtypeStruct(x_shape, x.dtype),
+        dparam_shape if scale is not None else dummy_shape,
+        dparam_shape if offset is not None else dummy_shape,
+    ]
+
+    dx, dscale_partial, doffset_partial = jt.triton_call(
+        dout, x, scale_arr, mean_flat, rstd_flat,
+        kernel=_normalization_vjp_kernel,
+        out_shape=out_shapes,
+        grid=grid,
+        num_warps=config.num_warps,
+        input_output_aliases={1: 0},  # x buffer reused for dx
+        M_dim=M,
+        A=A,
+        N_dim=N,
+        stride_m=A * N,
+        stride_a=N,
+        scale_offset=scale_offset,
+        grid_n=grid_n,
+        BLOCK_M=block_m,
+        BLOCK_A=block_a,
+        BLOCK_N=block_n,
+        HAS_SCALE=scale is not None,
+        HAS_OFFSET=offset is not None,
+        SUBTRACT_MEAN=subtract_mean,
+    )
+
+    dscale = None
+    if scale is not None:
+      dscale = jnp.sum(dscale_partial, axis=0).astype(scale.dtype)
+
+    doffset = None
+    if offset is not None:
+      doffset = jnp.sum(doffset_partial, axis=0).astype(offset.dtype)
+
+    return (dx.reshape(orig_x_shape), dscale, doffset), None
+
+  @override
+  def _get_heuristics_config(self, ba: op.BoundArguments) -> VjpConfig:
+    return pallas_triton_vjp_config.get_heuristics_config(
+        *ba.args, vmap_axis_sizes=ba.vmap_axis_sizes, **ba.kwargs
+    )
+
+  @override
+  def _get_autotuning_cache_key(self, ba: op.BoundArguments) -> VjpKey:
+    return pallas_triton_vjp_config.get_key(*ba.args, **ba.kwargs)
+
+  @override
+  def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[VjpConfig]:
+    axis = ba.kwargs['axis']
+    dout_shape = pallas_triton_config.canonicalize_shape(ba.args[2].shape, axis)
+    configs = set()
+    for num_warps in [1, 2, 4, 8, 16]:
+      for block_m in [1, 2, 4, 8, 16, 32, 64, 128]:
+        if block_m > pl.next_power_of_2(dout_shape[0]):
+          break
+        config = VjpConfig(block_m=block_m, block_n=None, num_warps=num_warps)
+        if len(dout_shape) > 2:
+          for block_n in [16, 32, 64, 128]:
+            if block_n > max(pl.next_power_of_2(dout_shape[2]), 16):
+              break
+            if 2 * block_m * dout_shape[1] * block_n <= _NUM_REGISTERS_PER_SM:
+              configs.add(dataclasses.replace(config, block_n=block_n))
+        elif 2 * block_m * dout_shape[1] <= _NUM_REGISTERS_PER_SM:
+          configs.add(config)
+    return configs
+
+  @override
+  def supported_on(self, device: jax.Device) -> bool:
+    return gpu_utils.has_triton_support(device)

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -1,4 +1,4 @@
-# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,8 +49,9 @@ def _normalization_kernel(
     X, SCALE, OFFSET,
     Y, MEAN, RSTD,
     # --- scalar args ---
-    M_dim, A, N_dim, stride_m, stride_a, epsilon, scale_offset,
+    M_dim, N_dim, stride_m, stride_a, epsilon, scale_offset,
     # --- constexpr args ---
+    A: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_A: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -139,8 +140,9 @@ def _normalization_vjp_kernel(
     DOUT, X, SCALE, MEAN, RSTD,
     DX, DSCALE, DOFFSET,
     # --- scalar args ---
-    M_dim, A, N_dim, stride_m, stride_a, scale_offset, grid_n,
+    M_dim, N_dim, stride_m, stride_a, scale_offset, grid_n,
     # --- constexpr args ---
+    A: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_A: tl.constexpr,
     BLOCK_N: tl.constexpr,

--- a/tokamax/_src/ops/normalization/jax_triton.py
+++ b/tokamax/_src/ops/normalization/jax_triton.py
@@ -44,71 +44,7 @@ _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
 
 
 @triton.jit
-def _normalization_kernel_2d(
-    # --- pointer args: inputs then outputs ---
-    X, SCALE, OFFSET,
-    Y, MEAN, RSTD,
-    # --- scalar args ---
-    M_dim, A, epsilon, scale_offset,
-    # --- constexpr args ---
-    BLOCK_M: tl.constexpr,
-    BLOCK_A: tl.constexpr,
-    HAS_SCALE: tl.constexpr,
-    HAS_OFFSET: tl.constexpr,
-    SUBTRACT_MEAN: tl.constexpr,
-    RETURN_MEAN: tl.constexpr,
-    RETURN_RSTD: tl.constexpr,
-):
-  """2D normalization forward kernel for the N=1 case (axis=-1).
-
-  1D grid over M. Each program handles a (BLOCK_M, BLOCK_A) tile, reducing
-  along axis 1 (A). Stats are 1D vectors of length M.
-  """
-  pid_m = tl.program_id(0)
-
-  x_blk = tl.make_block_ptr(
-      X, shape=(M_dim, A), strides=(A, 1),
-      offsets=(pid_m * BLOCK_M, 0),
-      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
-  )
-  x = tl.load(x_blk, boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-
-  a_offs = tl.arange(0, BLOCK_A)
-  a_mask = a_offs < A
-  m_off = pid_m * BLOCK_M
-  m_offs = m_off + tl.arange(0, BLOCK_M)
-  m_mask = m_offs < M_dim
-
-  if SUBTRACT_MEAN:
-    mean = tl.sum(x, axis=1) / A
-    if RETURN_MEAN:
-      tl.store(MEAN + m_offs, mean, mask=m_mask)
-    x = x - mean[:, None]
-    x = tl.where(a_mask[None, :], x, 0.0)
-
-  var = tl.sum(x * x, axis=1) / A
-  rstd = 1.0 / tl.sqrt(var + epsilon)
-  if RETURN_RSTD:
-    tl.store(RSTD + m_offs, rstd, mask=m_mask)
-  x = x * rstd[:, None]
-
-  if HAS_SCALE:
-    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    x = x * (s[None, :] + scale_offset)
-  if HAS_OFFSET:
-    o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    x = x + o[None, :]
-
-  y_blk = tl.make_block_ptr(
-      Y, shape=(M_dim, A), strides=(A, 1),
-      offsets=(pid_m * BLOCK_M, 0),
-      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
-  )
-  tl.store(y_blk, x.to(Y.dtype.element_ty), boundary_check=(0, 1))
-
-
-@triton.jit
-def _normalization_kernel_3d(
+def _normalization_kernel(
     # --- pointer args: inputs then outputs ---
     X, SCALE, OFFSET,
     Y, MEAN, RSTD,
@@ -124,134 +60,70 @@ def _normalization_kernel_3d(
     RETURN_MEAN: tl.constexpr,
     RETURN_RSTD: tl.constexpr,
 ):
-  """3D normalization forward kernel for the general case.
+  """Normalization forward kernel (layer norm / RMS norm).
 
-  Operates on a canonicalized (M, A, N) layout where A is the norm axis.
-  2D grid (pid_m, pid_n) tiles over M and N; each program reduces a full
-  (BLOCK_M, A, BLOCK_N) tile along A.
+  Input buffer is canonicalized (M, A, N) with A the norm axis, but the
+  in-register tile is laid out (M, N, A) so the reduced axis A is innermost.
+  This lets Triton lane-map the reduction efficiently even when N == 1 (the
+  axis=-1 case), matching Pallas without a separate 2D kernel.
   """
   pid_m = tl.program_id(0)
   pid_n = tl.program_id(1)
+  m_off = pid_m * BLOCK_M
+  n_off = pid_n * BLOCK_N
 
-  # Block pointers for the 3D x/y tile.
+  # (M, N, A) view: N contiguous (stride 1), A strided by N. order lists dims
+  # minor→major: N (stride 1), A (stride N), M (stride A*N).
   x_blk = tl.make_block_ptr(
-      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
-      offsets=(pid_m * BLOCK_M, 0, pid_n * BLOCK_N),
-      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+      X, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
+      offsets=(m_off, n_off, 0),
+      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
   )
   x = tl.load(x_blk, boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
 
   a_offs = tl.arange(0, BLOCK_A)
   a_mask = a_offs < A
 
-  # Stat offsets for block pointers.
-  stat_m_off = pid_m * BLOCK_M
-  stat_n_off = pid_n * BLOCK_N
-
   if SUBTRACT_MEAN:
-    mean = tl.sum(x, axis=1) / A
+    mean = tl.sum(x, axis=2) / A
     if RETURN_MEAN:
       mean_blk = tl.make_block_ptr(
           MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
-          offsets=(stat_m_off, stat_n_off),
+          offsets=(m_off, n_off),
           block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
       )
       tl.store(mean_blk, mean, boundary_check=(0, 1))
-    x = x - tl.expand_dims(mean, 1)
+    x = x - mean[:, :, None]
     # Zero invalid values (when A is not a power of two).
-    x = tl.where(a_mask[None, :, None], x, 0.0)
+    x = tl.where(a_mask[None, None, :], x, 0.0)
 
-  var = tl.sum(x * x, axis=1) / A
+  var = tl.sum(x * x, axis=2) / A
   rstd = 1.0 / tl.sqrt(var + epsilon)
   if RETURN_RSTD:
     rstd_blk = tl.make_block_ptr(
         RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
-        offsets=(stat_m_off, stat_n_off),
+        offsets=(m_off, n_off),
         block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
     )
     tl.store(rstd_blk, rstd, boundary_check=(0, 1))
-  x = x * tl.expand_dims(rstd, 1)
+  x = x * rstd[:, :, None]
 
   if HAS_SCALE:
     s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    x = x * (s[None, :, None] + scale_offset)
+    x = x * (s[None, None, :] + scale_offset)
   if HAS_OFFSET:
     o = tl.load(OFFSET + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    x = x + o[None, :, None]
+    x = x + o[None, None, :]
 
   y_blk = tl.make_block_ptr(
-      Y, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
-      offsets=(pid_m * BLOCK_M, 0, pid_n * BLOCK_N),
-      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+      Y, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
+      offsets=(m_off, n_off, 0),
+      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
   )
   tl.store(y_blk, x.to(Y.dtype.element_ty), boundary_check=(0, 1, 2))
 
 
 # ── VJP kernel ──────────────────────────────────────────────────────────────────
-
-
-@triton.jit
-def _normalization_vjp_kernel_2d(
-    # --- pointer args: inputs then outputs ---
-    DOUT, X, SCALE, MEAN, RSTD,
-    DX, DSCALE, DOFFSET,
-    # --- scalar args ---
-    M_dim, A, scale_offset,
-    # --- constexpr args ---
-    BLOCK_M: tl.constexpr,
-    BLOCK_A: tl.constexpr,
-    HAS_SCALE: tl.constexpr,
-    HAS_OFFSET: tl.constexpr,
-    SUBTRACT_MEAN: tl.constexpr,
-):
-  """2D normalization VJP kernel for the N=1 case."""
-  pid_m = tl.program_id(0)
-  m_off = pid_m * BLOCK_M
-
-  a_offs = tl.arange(0, BLOCK_A)
-  a_mask = a_offs < A
-  m_offs = m_off + tl.arange(0, BLOCK_M)
-  m_mask = m_offs < M_dim
-
-  x_norm = tl.load(tl.make_block_ptr(
-      X, shape=(M_dim, A), strides=(A, 1),
-      offsets=(m_off, 0),
-      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
-  ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-  if SUBTRACT_MEAN:
-    mean = tl.load(MEAN + m_offs, mask=m_mask, other=0.0).to(tl.float32)
-    x_norm = x_norm - mean[:, None]
-  rstd = tl.load(RSTD + m_offs, mask=m_mask, other=0.0).to(tl.float32)
-  x_norm = x_norm * rstd[:, None]
-
-  dout = tl.load(tl.make_block_ptr(
-      DOUT, shape=(M_dim, A), strides=(A, 1),
-      offsets=(m_off, 0),
-      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
-  ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-
-  if HAS_OFFSET:
-    doffset = tl.sum(dout, axis=0)
-    tl.store(DOFFSET + pid_m * A + a_offs, doffset, mask=a_mask)
-
-  if HAS_SCALE:
-    dscale = tl.sum(dout * x_norm, axis=0)
-    tl.store(DSCALE + pid_m * A + a_offs, dscale, mask=a_mask)
-    s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    dout = dout * (s[None, :] + scale_offset)
-
-  dx1 = -(tl.sum(dout * x_norm, axis=1) / A)
-  dx = dout + dx1[:, None] * x_norm
-  if SUBTRACT_MEAN:
-    dx2 = -(tl.sum(dout, axis=1) / A)
-    dx = dx + dx2[:, None]
-  dx = dx * rstd[:, None]
-
-  tl.store(tl.make_block_ptr(
-      DX, shape=(M_dim, A), strides=(A, 1),
-      offsets=(m_off, 0),
-      block_shape=(BLOCK_M, BLOCK_A), order=(1, 0),
-  ), dx.to(DX.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.jit
@@ -271,71 +143,72 @@ def _normalization_vjp_kernel(
 ):
   """Normalization VJP kernel.
 
+  In-register tile is laid out (M, N, A) with A innermost (see forward kernel).
   2D grid (pid_m, pid_n). Produces per-program partial sums for dscale and
   doffset (shape (grid_m * grid_n, A)), reduced outside the kernel.
   """
   pid_m = tl.program_id(0)
   pid_n = tl.program_id(1)
-  tile_m_off = pid_m * BLOCK_M
-  tile_n_off = pid_n * BLOCK_N
+  m_off = pid_m * BLOCK_M
+  n_off = pid_n * BLOCK_N
 
   a_offs = tl.arange(0, BLOCK_A)
   a_mask = a_offs < A
 
-  # Compute x_norm = (x - mean) * rstd.
+  # Compute x_norm = (x - mean) * rstd. Tile viewed as (M, N, A), A innermost.
   x_norm = tl.load(tl.make_block_ptr(
-      X, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
-      offsets=(tile_m_off, 0, tile_n_off),
-      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+      X, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
+      offsets=(m_off, n_off, 0),
+      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
   ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
   if SUBTRACT_MEAN:
     mean = tl.load(tl.make_block_ptr(
         MEAN, shape=(M_dim, N_dim), strides=(N_dim, 1),
-        offsets=(tile_m_off, tile_n_off),
+        offsets=(m_off, n_off),
         block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
     ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-    x_norm = x_norm - tl.expand_dims(mean, 1)
+    x_norm = x_norm - mean[:, :, None]
   rstd = tl.load(tl.make_block_ptr(
       RSTD, shape=(M_dim, N_dim), strides=(N_dim, 1),
-      offsets=(tile_m_off, tile_n_off),
+      offsets=(m_off, n_off),
       block_shape=(BLOCK_M, BLOCK_N), order=(1, 0),
   ), boundary_check=(0, 1), padding_option='zero').to(tl.float32)
-  x_norm = x_norm * tl.expand_dims(rstd, 1)
+  x_norm = x_norm * rstd[:, :, None]
 
   # Load dout tile.
   dout = tl.load(tl.make_block_ptr(
-      DOUT, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
-      offsets=(tile_m_off, 0, tile_n_off),
-      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+      DOUT, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
+      offsets=(m_off, n_off, 0),
+      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
   ), boundary_check=(0, 1, 2), padding_option='zero').to(tl.float32)
 
-  # Partial doffset/dscale: reduce (BM, BA, BN) → (BA,) via two sum axes.
+  # Partial doffset/dscale: reduce (BM, BN, BA) over M and N → (BA,).
   # Store as (linear_pid, A); host sums axis 0 to get (A,).
   linear_pid = pid_m * grid_n + pid_n
 
   if HAS_OFFSET:
-    doffset = tl.sum(tl.sum(dout, axis=2), axis=0)
+    doffset = tl.sum(tl.sum(dout, axis=1), axis=0)
     tl.store(DOFFSET + linear_pid * A + a_offs, doffset, mask=a_mask)
 
   if HAS_SCALE:
-    dscale = tl.sum(tl.sum(dout * x_norm, axis=2), axis=0)
+    dscale = tl.sum(tl.sum(dout * x_norm, axis=1), axis=0)
     tl.store(DSCALE + linear_pid * A + a_offs, dscale, mask=a_mask)
     s = tl.load(SCALE + a_offs, mask=a_mask, other=0.0).to(tl.float32)
-    dout = dout * (s[None, :, None] + scale_offset)
+    dout = dout * (s[None, None, :] + scale_offset)
 
   # dx = (dout - mean_a(dout·x_norm)·x_norm [- mean_a(dout)]) * rstd
-  # Reductions over axis 1 (the A dimension).
-  dx1 = tl.expand_dims(-(tl.sum(dout * x_norm, axis=1) / A), 1)
-  dx = dout + dx1 * x_norm
+  # Reductions over axis 2 (the A dimension).
+  dx1 = -(tl.sum(dout * x_norm, axis=2) / A)
+  dx = dout + dx1[:, :, None] * x_norm
   if SUBTRACT_MEAN:
-    dx2 = tl.expand_dims(-(tl.sum(dout, axis=1) / A), 1)
-    dx = dx + dx2
-  dx = dx * tl.expand_dims(rstd, 1)
+    dx2 = -(tl.sum(dout, axis=2) / A)
+    dx = dx + dx2[:, :, None]
+  dx = dx * rstd[:, :, None]
 
   tl.store(tl.make_block_ptr(
-      DX, shape=(M_dim, A, N_dim), strides=(stride_m, stride_a, 1),
-      offsets=(tile_m_off, 0, tile_n_off),
-      block_shape=(BLOCK_M, BLOCK_A, BLOCK_N), order=(2, 1, 0),
+      DX, shape=(M_dim, N_dim, A), strides=(stride_m, 1, stride_a),
+      offsets=(m_off, n_off, 0),
+      block_shape=(BLOCK_M, BLOCK_N, BLOCK_A), order=(1, 2, 0),
   ), dx.to(DX.dtype.element_ty), boundary_check=(0, 1, 2))
 
 
@@ -400,64 +273,35 @@ class JaxTritonNormalization(base.Normalization[Config, Key]):
     if input_output_alias:
       alias_kwargs['input_output_aliases'] = {0: 0}
 
-    if N == 1:
-      # 2D fast path: (M, A) layout, 1D grid, no N dimension overhead.
-      x = x.reshape(M, A)
-      out_shapes = [
-          jax.ShapeDtypeStruct((M, A), x.dtype),
-          jax.ShapeDtypeStruct((M,), jnp.float32),
-          jax.ShapeDtypeStruct((M,), jnp.float32),
-      ]
-      y, mean_flat, rstd_flat = jt.triton_call(
-          x, scale_arr, offset_arr,
-          kernel=_normalization_kernel_2d,
-          out_shape=out_shapes,
-          grid=(pl.cdiv(M, block_m),),
-          num_warps=config.num_warps,
-          **alias_kwargs,
-          M_dim=M,
-          A=A,
-          epsilon=epsilon,
-          scale_offset=scale_offset,
-          BLOCK_M=block_m,
-          BLOCK_A=block_a,
-          HAS_SCALE=scale is not None,
-          HAS_OFFSET=offset is not None,
-          SUBTRACT_MEAN=subtract_mean,
-          RETURN_MEAN=return_residuals and subtract_mean,
-          RETURN_RSTD=return_residuals,
-      )
-    else:
-      # 3D general path.
-      grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
-      out_shapes = [
-          jax.ShapeDtypeStruct(x_shape, x.dtype),
-          jax.ShapeDtypeStruct((num_rows,), jnp.float32),
-          jax.ShapeDtypeStruct((num_rows,), jnp.float32),
-      ]
-      y, mean_flat, rstd_flat = jt.triton_call(
-          x, scale_arr, offset_arr,
-          kernel=_normalization_kernel_3d,
-          out_shape=out_shapes,
-          grid=grid,
-          num_warps=config.num_warps,
-          **alias_kwargs,
-          M_dim=M,
-          A=A,
-          N_dim=N,
-          stride_m=A * N,
-          stride_a=N,
-          epsilon=epsilon,
-          scale_offset=scale_offset,
-          BLOCK_M=block_m,
-          BLOCK_A=block_a,
-          BLOCK_N=block_n,
-          HAS_SCALE=scale is not None,
-          HAS_OFFSET=offset is not None,
-          SUBTRACT_MEAN=subtract_mean,
-          RETURN_MEAN=return_residuals and subtract_mean,
-          RETURN_RSTD=return_residuals,
-      )
+    grid = (pl.cdiv(M, block_m), pl.cdiv(N, block_n))
+    out_shapes = [
+        jax.ShapeDtypeStruct(x_shape, x.dtype),
+        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
+        jax.ShapeDtypeStruct((num_rows,), jnp.float32),
+    ]
+    y, mean_flat, rstd_flat = jt.triton_call(
+        x, scale_arr, offset_arr,
+        kernel=_normalization_kernel,
+        out_shape=out_shapes,
+        grid=grid,
+        num_warps=config.num_warps,
+        **alias_kwargs,
+        M_dim=M,
+        A=A,
+        N_dim=N,
+        stride_m=A * N,
+        stride_a=N,
+        epsilon=epsilon,
+        scale_offset=scale_offset,
+        BLOCK_M=block_m,
+        BLOCK_A=block_a,
+        BLOCK_N=block_n,
+        HAS_SCALE=scale is not None,
+        HAS_OFFSET=offset is not None,
+        SUBTRACT_MEAN=subtract_mean,
+        RETURN_MEAN=return_residuals and subtract_mean,
+        RETURN_RSTD=return_residuals,
+    )
 
     y = y.reshape(orig_x_shape)
 
@@ -563,67 +407,37 @@ class JaxTritonNormalizationVjp(base.NormalizationVjp[VjpConfig, VjpKey]):
     scale_arr = scale if scale is not None else dummy
 
     grid_m = pl.cdiv(M, block_m)
-
-    if N == 1:
-      # 2D fast path.
-      x = x.reshape(M, A)
-      dout = dout.reshape(M, A)
-      dparam_shape = jax.ShapeDtypeStruct((grid_m, A), jnp.float32)
-      dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
-      out_shapes = [
-          jax.ShapeDtypeStruct((M, A), x.dtype),
-          dparam_shape if scale is not None else dummy_shape,
-          dparam_shape if offset is not None else dummy_shape,
-      ]
-      dx, dscale_partial, doffset_partial = jt.triton_call(
-          dout, x, scale_arr, mean_flat, rstd_flat,
-          kernel=_normalization_vjp_kernel_2d,
-          out_shape=out_shapes,
-          grid=(grid_m,),
-          num_warps=config.num_warps,
-          input_output_aliases={1: 0},
-          M_dim=M,
-          A=A,
-          scale_offset=scale_offset,
-          BLOCK_M=block_m,
-          BLOCK_A=block_a,
-          HAS_SCALE=scale is not None,
-          HAS_OFFSET=offset is not None,
-          SUBTRACT_MEAN=subtract_mean,
-      )
-    else:
-      # 3D general path.
-      grid_n = pl.cdiv(N, block_n)
-      grid = (grid_m, grid_n)
-      num_programs = grid_m * grid_n
-      dparam_shape = jax.ShapeDtypeStruct((num_programs, A), jnp.float32)
-      dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
-      out_shapes = [
-          jax.ShapeDtypeStruct(x_shape, x.dtype),
-          dparam_shape if scale is not None else dummy_shape,
-          dparam_shape if offset is not None else dummy_shape,
-      ]
-      dx, dscale_partial, doffset_partial = jt.triton_call(
-          dout, x, scale_arr, mean_flat, rstd_flat,
-          kernel=_normalization_vjp_kernel,
-          out_shape=out_shapes,
-          grid=grid,
-          num_warps=config.num_warps,
-          input_output_aliases={1: 0},
-          M_dim=M,
-          A=A,
-          N_dim=N,
-          stride_m=A * N,
-          stride_a=N,
-          scale_offset=scale_offset,
-          grid_n=grid_n,
-          BLOCK_M=block_m,
-          BLOCK_A=block_a,
-          BLOCK_N=block_n,
-          HAS_SCALE=scale is not None,
-          HAS_OFFSET=offset is not None,
-          SUBTRACT_MEAN=subtract_mean,
-      )
+    grid_n = pl.cdiv(N, block_n)
+    grid = (grid_m, grid_n)
+    num_programs = grid_m * grid_n
+    dparam_shape = jax.ShapeDtypeStruct((num_programs, A), jnp.float32)
+    dummy_shape = jax.ShapeDtypeStruct((1,), jnp.float32)
+    out_shapes = [
+        jax.ShapeDtypeStruct(x_shape, x.dtype),
+        dparam_shape if scale is not None else dummy_shape,
+        dparam_shape if offset is not None else dummy_shape,
+    ]
+    dx, dscale_partial, doffset_partial = jt.triton_call(
+        dout, x, scale_arr, mean_flat, rstd_flat,
+        kernel=_normalization_vjp_kernel,
+        out_shape=out_shapes,
+        grid=grid,
+        num_warps=config.num_warps,
+        input_output_aliases={1: 0},
+        M_dim=M,
+        A=A,
+        N_dim=N,
+        stride_m=A * N,
+        stride_a=N,
+        scale_offset=scale_offset,
+        grid_n=grid_n,
+        BLOCK_M=block_m,
+        BLOCK_A=block_a,
+        BLOCK_N=block_n,
+        HAS_SCALE=scale is not None,
+        HAS_OFFSET=offset is not None,
+        SUBTRACT_MEAN=subtract_mean,
+    )
 
     dscale = None
     if scale is not None:

--- a/tokamax/_src/ops/normalization/jax_triton_test.py
+++ b/tokamax/_src/ops/normalization/jax_triton_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+# Copyright 2026 DeepMind Technologies Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
 """Tests for jax-triton normalization op."""
 
 import functools
+from typing import override
+from unittest import mock
 
 from absl.testing import absltest
-from absl.testing import parameterized
 import chex
 import jax
 from tokamax._src.ops.normalization import jax_triton
-from tokamax._src.ops.normalization import pallas_triton
+from tokamax._src.ops.normalization import pallas_triton_config
 from tokamax._src.ops.normalization import test_base
 
 
@@ -36,57 +37,93 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
       self.skipTest('Not supported on TPUs.')
     super().setUp()
 
+  def test_layer_norm_with_pre_scale(self):
+    rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
 
-class JaxTritonVsPallasTritonTest(parameterized.TestCase):
-  """Cross-checks that jax-triton and pallas-triton produce the same results."""
-
-  def setUp(self):
-    if jax.default_backend() == 'tpu':
-      self.skipTest('Not supported on TPUs.')
-    super().setUp()
-    self._jt = jax_triton.JaxTritonNormalization(input_output_alias=False)
-    self._pt = pallas_triton.PallasTritonNormalization(input_output_alias=False)
-
-  @parameterized.parameters(
-      dict(shape=(128, 64), axis=-1, subtract_mean=True),
-      dict(shape=(128, 64), axis=-1, subtract_mean=False),
-      dict(shape=(8, 128, 32), axis=-1, subtract_mean=True),
-      dict(shape=(24, 32, 40), axis=1, subtract_mean=True),
-      dict(shape=(256, 42), axis=-1, subtract_mean=True),
-  )
-  def test_fwd_matches(self, shape, axis, subtract_mean):
-    rngs = list(jax.random.split(jax.random.PRNGKey(42), 3))
+    shape = (128, 32)
     x = jax.random.normal(rngs.pop(), shape)
-    scale = jax.random.uniform(rngs.pop(), (shape[axis],))
-    offset = jax.random.uniform(rngs.pop(), (shape[axis],))
+    scale = jax.random.uniform(rngs.pop(), (shape[-1],))
+    offset = jax.random.uniform(rngs.pop(), (shape[-1],))
+    pre_scale = jax.random.uniform(rngs.pop(), (shape[-1],))
+    epsilon = 1e-6
 
-    kwargs = dict(axis=axis, epsilon=1e-6, subtract_mean=subtract_mean)
-    y_pt = self._pt(x, scale, offset, **kwargs)
-    y_jt = self._jt(x, scale, offset, **kwargs)
-    chex.assert_trees_all_close(y_jt, y_pt, atol=1e-5)
+    y_expected = jax.nn.standardize(x * pre_scale, epsilon=epsilon) * scale
+    y_expected += offset
+    y_actual = self._norm_fn(
+        lambda: x * pre_scale, scale, offset, epsilon=epsilon
+    )
+    chex.assert_trees_all_close(y_actual, y_expected, atol=1e-6)
 
-  @parameterized.parameters(
-      dict(shape=(128, 64), axis=-1, subtract_mean=True),
-      dict(shape=(128, 64), axis=-1, subtract_mean=False),
-      dict(shape=(24, 32, 40), axis=1, subtract_mean=True),
-  )
-  def test_vjp_matches(self, shape, axis, subtract_mean):
-    rngs = list(jax.random.split(jax.random.PRNGKey(42), 4))
+  @override
+  def _test_layer_norm_vmap(self, axis, vmap_in_axes):
+    x_shape = [24, 32, 40]
+    vmap_axis_sizes = tuple(
+        x_shape.pop(in_axes[0]) for in_axes in vmap_in_axes[::-1]
+    )
+
+    seen_vmap_axis_sizes = []
+    get_heuristics_config = pallas_triton_config.get_heuristics_config
+
+    def my_heuristics_config(*args, **kwargs):
+      seen_vmap_axis_sizes.append(kwargs['vmap_axis_sizes'])
+      return get_heuristics_config(*args, **kwargs)
+
+    with mock.patch.object(
+        pallas_triton_config, 'get_heuristics_config', my_heuristics_config
+    ):
+      super()._test_layer_norm_vmap(axis, vmap_in_axes)
+
+    # We expect to see a shape for non-vmapped and each layer of vmap.
+    seen_vmap_axis_sizes = seen_vmap_axis_sizes[-1 :: -(len(vmap_in_axes) + 1)]
+    # We expect three calls from fwd, fwd res, and VJP.
+    self.assertEqual(seen_vmap_axis_sizes, [vmap_axis_sizes] * 3)
+
+  def test_remat(self):
+    rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
+
+    shape = (128, 32)
     x = jax.random.normal(rngs.pop(), shape)
-    scale = jax.random.uniform(rngs.pop(), (shape[axis],))
-    offset = jax.random.uniform(rngs.pop(), (shape[axis],))
-    dy = jax.random.normal(rngs.pop(), shape)
+    scale = jax.random.uniform(rngs.pop(), (shape[-1],))
+    offset = jax.random.uniform(rngs.pop(), (shape[-1],))
+    epsilon = 1e-6
 
-    kwargs = dict(axis=axis, epsilon=1e-6, subtract_mean=subtract_mean)
-    f_pt = functools.partial(self._pt, **kwargs)
-    f_jt = functools.partial(self._jt, **kwargs)
+    f = functools.partial(self._norm_fn, epsilon=epsilon)
+    g_ref = jax.value_and_grad(lambda *args: f(*args).sum())
+    g_remat = jax.value_and_grad(lambda *args: jax.remat(f)(*args).sum())
+    g_remat_lowered = jax.jit(g_remat).lower(x, scale, offset)
 
-    _, vjp_pt = jax.vjp(f_pt, x, scale, offset)
-    _, vjp_jt = jax.vjp(f_jt, x, scale, offset)
+    # jax-triton lowers every kernel to the same `triton_kernel_call` target
+    # (no per-kernel names like pallas), so we count the total instead of
+    # per-name: remat gives fwd + recomputed fwd-res + vjp = 3.
+    hlo = str(g_remat_lowered.compiler_ir('stablehlo'))
+    self.assertEqual(hlo.count('triton_kernel_call'), 3, msg=hlo)
 
-    grads_pt = vjp_pt(dy)
-    grads_jt = vjp_jt(dy)
-    chex.assert_trees_all_close(grads_jt, grads_pt, atol=1e-4)
+    g_out = g_remat_lowered.compile()(x, scale, offset)
+    chex.assert_trees_all_equal(g_out, g_ref(x, scale, offset))
+
+  def test_remat_with_vmap(self):
+    rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
+
+    shape = (3, 128, 32)
+    x = jax.random.normal(rngs.pop(), shape)
+    scale = jax.random.uniform(rngs.pop(), (shape[0], shape[-1]))
+    offset = jax.random.uniform(rngs.pop(), (shape[0], shape[-1]))
+    epsilon = 1e-6
+
+    def f(x, scale, offset):
+      return self._norm_fn(x, scale, offset, epsilon=epsilon)
+
+    g_ref = jax.vmap(jax.value_and_grad(lambda *args: f(*args).sum()))
+    g_remat = jax.vmap(
+        jax.value_and_grad(lambda *args: jax.remat(f)(*args).sum())
+    )
+    g_remat_lowered = jax.jit(g_remat).lower(x, scale, offset)
+
+    hlo = str(g_remat_lowered.compiler_ir('stablehlo'))
+    self.assertEqual(hlo.count('triton_kernel_call'), 3, msg=hlo)
+
+    g_out = g_remat_lowered.compile()(x, scale, offset)
+    chex.assert_trees_all_equal(g_out, g_ref(x, scale, offset))
 
 
 if __name__ == '__main__':

--- a/tokamax/_src/ops/normalization/jax_triton_test.py
+++ b/tokamax/_src/ops/normalization/jax_triton_test.py
@@ -22,7 +22,7 @@ from absl.testing import absltest
 import chex
 import jax
 from tokamax._src.ops.normalization import jax_triton
-from tokamax._src.ops.normalization import pallas_triton_config
+from tokamax._src.ops.normalization import triton_config
 from tokamax._src.ops.normalization import test_base
 
 
@@ -62,14 +62,14 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     )
 
     seen_vmap_axis_sizes = []
-    get_heuristics_config = pallas_triton_config.get_heuristics_config
+    get_heuristics_config = triton_config.get_heuristics_config
 
     def my_heuristics_config(*args, **kwargs):
       seen_vmap_axis_sizes.append(kwargs['vmap_axis_sizes'])
       return get_heuristics_config(*args, **kwargs)
 
     with mock.patch.object(
-        pallas_triton_config, 'get_heuristics_config', my_heuristics_config
+        triton_config, 'get_heuristics_config', my_heuristics_config
     ):
       super()._test_layer_norm_vmap(axis, vmap_in_axes)
 

--- a/tokamax/_src/ops/normalization/jax_triton_test.py
+++ b/tokamax/_src/ops/normalization/jax_triton_test.py
@@ -15,11 +15,14 @@
 """Tests for jax-triton normalization op."""
 
 import functools
+from typing import override
+from unittest import mock
 
 from absl.testing import absltest
 import chex
 import jax
 from tokamax._src.ops.normalization import jax_triton
+from tokamax._src.ops.normalization import triton_config
 from tokamax._src.ops.normalization import test_base
 
 
@@ -33,15 +36,6 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     if jax.default_backend() == 'tpu':
       self.skipTest('Not supported on TPUs.')
     super().setUp()
-
-  # `jax_triton.triton_call` has no `jax.vmap` batching rule (it raises by
-  # design; the rule is inherently per-kernel). Skipping the shared helper skips
-  # all parameterized `test_layer_norm_vmap*` cases until a
-  # `jax.custom_batching.custom_vmap` rule is added to `JaxTritonNormalization`
-  # (see `triton_call_vmap_plan.md`). TODO: re-enable (with the heuristics-mock
-  # override and `test_remat_with_vmap` from `pallas_triton_test.py`) then.
-  def _test_layer_norm_vmap(self, axis, vmap_in_axes):
-    self.skipTest('jax_triton normalization does not support `vmap` yet.')
 
   def test_layer_norm_with_pre_scale(self):
     rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
@@ -60,6 +54,30 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     )
     chex.assert_trees_all_close(y_actual, y_expected, atol=1e-6)
 
+  @override
+  def _test_layer_norm_vmap(self, axis, vmap_in_axes):
+    x_shape = [24, 32, 40]
+    vmap_axis_sizes = tuple(
+        x_shape.pop(in_axes[0]) for in_axes in vmap_in_axes[::-1]
+    )
+
+    seen_vmap_axis_sizes = []
+    get_heuristics_config = triton_config.get_heuristics_config
+
+    def my_heuristics_config(*args, **kwargs):
+      seen_vmap_axis_sizes.append(kwargs['vmap_axis_sizes'])
+      return get_heuristics_config(*args, **kwargs)
+
+    with mock.patch.object(
+        triton_config, 'get_heuristics_config', my_heuristics_config
+    ):
+      super()._test_layer_norm_vmap(axis, vmap_in_axes)
+
+    # We expect to see a shape for non-vmapped and each layer of vmap.
+    seen_vmap_axis_sizes = seen_vmap_axis_sizes[-1 :: -(len(vmap_in_axes) + 1)]
+    # We expect three calls from fwd, fwd res, and VJP.
+    self.assertEqual(seen_vmap_axis_sizes, [vmap_axis_sizes] * 3)
+
   def test_remat(self):
     rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
 
@@ -77,6 +95,30 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     # jax-triton lowers every kernel to the same `triton_kernel_call` target
     # (no per-kernel names like pallas), so we count the total instead of
     # per-name: remat gives fwd + recomputed fwd-res + vjp = 3.
+    hlo = str(g_remat_lowered.compiler_ir('stablehlo'))
+    self.assertEqual(hlo.count('triton_kernel_call'), 3, msg=hlo)
+
+    g_out = g_remat_lowered.compile()(x, scale, offset)
+    chex.assert_trees_all_equal(g_out, g_ref(x, scale, offset))
+
+  def test_remat_with_vmap(self):
+    rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
+
+    shape = (3, 128, 32)
+    x = jax.random.normal(rngs.pop(), shape)
+    scale = jax.random.uniform(rngs.pop(), (shape[0], shape[-1]))
+    offset = jax.random.uniform(rngs.pop(), (shape[0], shape[-1]))
+    epsilon = 1e-6
+
+    def f(x, scale, offset):
+      return self._norm_fn(x, scale, offset, epsilon=epsilon)
+
+    g_ref = jax.vmap(jax.value_and_grad(lambda *args: f(*args).sum()))
+    g_remat = jax.vmap(
+        jax.value_and_grad(lambda *args: jax.remat(f)(*args).sum())
+    )
+    g_remat_lowered = jax.jit(g_remat).lower(x, scale, offset)
+
     hlo = str(g_remat_lowered.compiler_ir('stablehlo'))
     self.assertEqual(hlo.count('triton_kernel_call'), 3, msg=hlo)
 

--- a/tokamax/_src/ops/normalization/jax_triton_test.py
+++ b/tokamax/_src/ops/normalization/jax_triton_test.py
@@ -15,14 +15,11 @@
 """Tests for jax-triton normalization op."""
 
 import functools
-from typing import override
-from unittest import mock
 
 from absl.testing import absltest
 import chex
 import jax
 from tokamax._src.ops.normalization import jax_triton
-from tokamax._src.ops.normalization import triton_config
 from tokamax._src.ops.normalization import test_base
 
 
@@ -36,6 +33,15 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     if jax.default_backend() == 'tpu':
       self.skipTest('Not supported on TPUs.')
     super().setUp()
+
+  # `jax_triton.triton_call` has no `jax.vmap` batching rule (it raises by
+  # design; the rule is inherently per-kernel). Skipping the shared helper skips
+  # all parameterized `test_layer_norm_vmap*` cases until a
+  # `jax.custom_batching.custom_vmap` rule is added to `JaxTritonNormalization`
+  # (see `triton_call_vmap_plan.md`). TODO: re-enable (with the heuristics-mock
+  # override and `test_remat_with_vmap` from `pallas_triton_test.py`) then.
+  def _test_layer_norm_vmap(self, axis, vmap_in_axes):
+    self.skipTest('jax_triton normalization does not support `vmap` yet.')
 
   def test_layer_norm_with_pre_scale(self):
     rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
@@ -54,30 +60,6 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     )
     chex.assert_trees_all_close(y_actual, y_expected, atol=1e-6)
 
-  @override
-  def _test_layer_norm_vmap(self, axis, vmap_in_axes):
-    x_shape = [24, 32, 40]
-    vmap_axis_sizes = tuple(
-        x_shape.pop(in_axes[0]) for in_axes in vmap_in_axes[::-1]
-    )
-
-    seen_vmap_axis_sizes = []
-    get_heuristics_config = triton_config.get_heuristics_config
-
-    def my_heuristics_config(*args, **kwargs):
-      seen_vmap_axis_sizes.append(kwargs['vmap_axis_sizes'])
-      return get_heuristics_config(*args, **kwargs)
-
-    with mock.patch.object(
-        triton_config, 'get_heuristics_config', my_heuristics_config
-    ):
-      super()._test_layer_norm_vmap(axis, vmap_in_axes)
-
-    # We expect to see a shape for non-vmapped and each layer of vmap.
-    seen_vmap_axis_sizes = seen_vmap_axis_sizes[-1 :: -(len(vmap_in_axes) + 1)]
-    # We expect three calls from fwd, fwd res, and VJP.
-    self.assertEqual(seen_vmap_axis_sizes, [vmap_axis_sizes] * 3)
-
   def test_remat(self):
     rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
 
@@ -95,30 +77,6 @@ class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
     # jax-triton lowers every kernel to the same `triton_kernel_call` target
     # (no per-kernel names like pallas), so we count the total instead of
     # per-name: remat gives fwd + recomputed fwd-res + vjp = 3.
-    hlo = str(g_remat_lowered.compiler_ir('stablehlo'))
-    self.assertEqual(hlo.count('triton_kernel_call'), 3, msg=hlo)
-
-    g_out = g_remat_lowered.compile()(x, scale, offset)
-    chex.assert_trees_all_equal(g_out, g_ref(x, scale, offset))
-
-  def test_remat_with_vmap(self):
-    rngs = list(jax.random.split(jax.random.PRNGKey(0), 4))
-
-    shape = (3, 128, 32)
-    x = jax.random.normal(rngs.pop(), shape)
-    scale = jax.random.uniform(rngs.pop(), (shape[0], shape[-1]))
-    offset = jax.random.uniform(rngs.pop(), (shape[0], shape[-1]))
-    epsilon = 1e-6
-
-    def f(x, scale, offset):
-      return self._norm_fn(x, scale, offset, epsilon=epsilon)
-
-    g_ref = jax.vmap(jax.value_and_grad(lambda *args: f(*args).sum()))
-    g_remat = jax.vmap(
-        jax.value_and_grad(lambda *args: jax.remat(f)(*args).sum())
-    )
-    g_remat_lowered = jax.jit(g_remat).lower(x, scale, offset)
-
     hlo = str(g_remat_lowered.compiler_ir('stablehlo'))
     self.assertEqual(hlo.count('triton_kernel_call'), 3, msg=hlo)
 

--- a/tokamax/_src/ops/normalization/jax_triton_test.py
+++ b/tokamax/_src/ops/normalization/jax_triton_test.py
@@ -1,0 +1,93 @@
+# Copyright 2025 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for jax-triton normalization op."""
+
+import functools
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+import jax
+from tokamax._src.ops.normalization import jax_triton
+from tokamax._src.ops.normalization import pallas_triton
+from tokamax._src.ops.normalization import test_base
+
+
+class JaxTritonNormalizationTest(test_base.NormalizationTestBase):
+  """Runs the standard normalization test suite against the jax-triton impl."""
+
+  def __init__(self, *args):
+    super().__init__(*args, norm_fn=jax_triton.JaxTritonNormalization())
+
+  def setUp(self):
+    if jax.default_backend() == 'tpu':
+      self.skipTest('Not supported on TPUs.')
+    super().setUp()
+
+
+class JaxTritonVsPallasTritonTest(parameterized.TestCase):
+  """Cross-checks that jax-triton and pallas-triton produce the same results."""
+
+  def setUp(self):
+    if jax.default_backend() == 'tpu':
+      self.skipTest('Not supported on TPUs.')
+    super().setUp()
+    self._jt = jax_triton.JaxTritonNormalization(input_output_alias=False)
+    self._pt = pallas_triton.PallasTritonNormalization(input_output_alias=False)
+
+  @parameterized.parameters(
+      dict(shape=(128, 64), axis=-1, subtract_mean=True),
+      dict(shape=(128, 64), axis=-1, subtract_mean=False),
+      dict(shape=(8, 128, 32), axis=-1, subtract_mean=True),
+      dict(shape=(24, 32, 40), axis=1, subtract_mean=True),
+      dict(shape=(256, 42), axis=-1, subtract_mean=True),
+  )
+  def test_fwd_matches(self, shape, axis, subtract_mean):
+    rngs = list(jax.random.split(jax.random.PRNGKey(42), 3))
+    x = jax.random.normal(rngs.pop(), shape)
+    scale = jax.random.uniform(rngs.pop(), (shape[axis],))
+    offset = jax.random.uniform(rngs.pop(), (shape[axis],))
+
+    kwargs = dict(axis=axis, epsilon=1e-6, subtract_mean=subtract_mean)
+    y_pt = self._pt(x, scale, offset, **kwargs)
+    y_jt = self._jt(x, scale, offset, **kwargs)
+    chex.assert_trees_all_close(y_jt, y_pt, atol=1e-5)
+
+  @parameterized.parameters(
+      dict(shape=(128, 64), axis=-1, subtract_mean=True),
+      dict(shape=(128, 64), axis=-1, subtract_mean=False),
+      dict(shape=(24, 32, 40), axis=1, subtract_mean=True),
+  )
+  def test_vjp_matches(self, shape, axis, subtract_mean):
+    rngs = list(jax.random.split(jax.random.PRNGKey(42), 4))
+    x = jax.random.normal(rngs.pop(), shape)
+    scale = jax.random.uniform(rngs.pop(), (shape[axis],))
+    offset = jax.random.uniform(rngs.pop(), (shape[axis],))
+    dy = jax.random.normal(rngs.pop(), shape)
+
+    kwargs = dict(axis=axis, epsilon=1e-6, subtract_mean=subtract_mean)
+    f_pt = functools.partial(self._pt, **kwargs)
+    f_jt = functools.partial(self._jt, **kwargs)
+
+    _, vjp_pt = jax.vjp(f_pt, x, scale, offset)
+    _, vjp_jt = jax.vjp(f_jt, x, scale, offset)
+
+    grads_pt = vjp_pt(dy)
+    grads_jt = vjp_jt(dy)
+    chex.assert_trees_all_close(grads_jt, grads_pt, atol=1e-4)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tokamax/_src/ops/normalization/pallas_triton.py
+++ b/tokamax/_src/ops/normalization/pallas_triton.py
@@ -26,13 +26,13 @@ import jax.numpy as jnp
 from tokamax._src import gpu_utils
 from tokamax._src.ops import op
 from tokamax._src.ops.normalization import base
-from tokamax._src.ops.normalization import pallas_triton_config
+from tokamax._src.ops.normalization import triton_config
 from tokamax._src.ops.normalization import pallas_triton_vjp
 from tokamax._src.pallas import block
 
 
-Config = pallas_triton_config.Config
-Key = pallas_triton_config.Key
+Config = triton_config.Config
+Key = triton_config.Key
 FusedInputArray = base.FusedInputArray
 _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
 
@@ -117,7 +117,7 @@ class PallasTritonNormalization(base.Normalization[Config, Key]):
 
     orig_x_shape = x.shape
     # Canonicalize to 3D, where the second axis is the reduced axis.
-    x_shape = pallas_triton_config.canonicalize_shape_3d(orig_x_shape, axis)
+    x_shape = triton_config.canonicalize_shape_3d(orig_x_shape, axis)
     x_shape_ty = jax.ShapeDtypeStruct(x_shape, x.dtype)
 
     if callable(x):
@@ -186,20 +186,20 @@ class PallasTritonNormalization(base.Normalization[Config, Key]):
 
   @override
   def _get_heuristics_config(self, ba: op.BoundArguments) -> Config:
-    return pallas_triton_config.get_heuristics_config(
+    return triton_config.get_heuristics_config(
         *ba.args, vmap_axis_sizes=ba.vmap_axis_sizes, **ba.kwargs
     )
 
   @override
   def _get_autotuning_cache_key(self, ba: op.BoundArguments) -> Key:
     # TODO: Use batched args.
-    return pallas_triton_config.get_key(*ba.args, **ba.kwargs)
+    return triton_config.get_key(*ba.args, **ba.kwargs)
 
   @override
   def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[Config]:
     x = ba.args[0]
     axis = ba.kwargs['axis']
-    x_shape = pallas_triton_config.canonicalize_shape(x.shape, axis)
+    x_shape = triton_config.canonicalize_shape(x.shape, axis)
     configs = set()
     # `num_stages` has no effect, as there is no loop within kernel.
     for num_warps in [1, 2, 4, 8, 16]:

--- a/tokamax/_src/ops/normalization/pallas_triton_test.py
+++ b/tokamax/_src/ops/normalization/pallas_triton_test.py
@@ -21,7 +21,7 @@ from absl.testing import absltest
 import chex
 import jax
 from tokamax._src.ops.normalization import pallas_triton
-from tokamax._src.ops.normalization import pallas_triton_config
+from tokamax._src.ops.normalization import triton_config
 from tokamax._src.ops.normalization import test_base
 
 
@@ -60,14 +60,14 @@ class PallasTritonNormalizationTest(test_base.NormalizationTestBase):
     )
 
     seen_vmap_axis_sizes = []
-    get_heuristics_config = pallas_triton_config.get_heuristics_config
+    get_heuristics_config = triton_config.get_heuristics_config
 
     def my_heuristics_config(*args, **kwargs):
       seen_vmap_axis_sizes.append(kwargs['vmap_axis_sizes'])
       return get_heuristics_config(*args, **kwargs)
 
     with mock.patch.object(
-        pallas_triton_config, 'get_heuristics_config', my_heuristics_config
+        triton_config, 'get_heuristics_config', my_heuristics_config
     ):
       super()._test_layer_norm_vmap(axis, vmap_in_axes)
 

--- a/tokamax/_src/ops/normalization/pallas_triton_vjp.py
+++ b/tokamax/_src/ops/normalization/pallas_triton_vjp.py
@@ -25,16 +25,16 @@ import jax.numpy as jnp
 from tokamax._src import gpu_utils
 from tokamax._src.ops import op
 from tokamax._src.ops.normalization import base
-from tokamax._src.ops.normalization import pallas_triton_config
-from tokamax._src.ops.normalization import pallas_triton_vjp_config
+from tokamax._src.ops.normalization import triton_config
+from tokamax._src.ops.normalization import triton_vjp_config
 from tokamax._src.pallas import block
 
 
 _NUM_REGISTERS_PER_SM = gpu_utils.NUM_REGISTERS_PER_SM
 
 
-Config = pallas_triton_vjp_config.Config
-Key = pallas_triton_vjp_config.Key
+Config = triton_vjp_config.Config
+Key = triton_vjp_config.Key
 Residuals = base.Residuals
 
 
@@ -116,13 +116,13 @@ class PallasTritonNormalizationVjp(base.NormalizationVjp[Config, Key]):
 
     # Cananonicalize to 3D, where the second axis is the reduced axis.
     orig_x_shape = x.shape
-    x = x.reshape(pallas_triton_config.canonicalize_shape_3d(x.shape, axis))
+    x = x.reshape(triton_config.canonicalize_shape_3d(x.shape, axis))
     dout = dout.reshape(x.shape)
 
     if scale is not None:
       scale = scale[:, None]
 
-    stat_shape = pallas_triton_config.canonicalize_shape_3d(rstddev.shape, axis)
+    stat_shape = triton_config.canonicalize_shape_3d(rstddev.shape, axis)
     if mean is not None:
       mean = mean.reshape(stat_shape)
     rstddev = rstddev.reshape(stat_shape)
@@ -167,19 +167,19 @@ class PallasTritonNormalizationVjp(base.NormalizationVjp[Config, Key]):
 
   @override
   def _get_heuristics_config(self, ba: op.BoundArguments) -> Config:
-    return pallas_triton_vjp_config.get_heuristics_config(
+    return triton_vjp_config.get_heuristics_config(
         *ba.args, vmap_axis_sizes=ba.vmap_axis_sizes, **ba.kwargs
     )
 
   @override
   def _get_autotuning_cache_key(self, ba: op.BoundArguments) -> Key:
     # TODO: Use batched args.
-    return pallas_triton_vjp_config.get_key(*ba.args, **ba.kwargs)
+    return triton_vjp_config.get_key(*ba.args, **ba.kwargs)
 
   @override
   def _get_autotuning_configs(self, ba: op.BoundArguments) -> set[Config]:
     axis = ba.kwargs['axis']
-    dout_shape = pallas_triton_config.canonicalize_shape(ba.args[1].shape, axis)
+    dout_shape = triton_config.canonicalize_shape(ba.args[1].shape, axis)
     configs = set()
     # `num_stages` has no effect, as there is no loop within kernel.
     for num_warps in [1, 2, 4, 8, 16]:

--- a/tokamax/_src/ops/normalization/triton_config.py
+++ b/tokamax/_src/ops/normalization/triton_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Pallas-Triton normalization op configuration."""
+"""Triton normalization op configuration."""
 
 from collections.abc import Sequence
 import math

--- a/tokamax/_src/ops/normalization/triton_vjp_config.py
+++ b/tokamax/_src/ops/normalization/triton_vjp_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Pallas-Triton normalization VJP configuration."""
+"""Triton normalization VJP configuration."""
 
 import dataclasses
 
@@ -21,7 +21,7 @@ import jax
 import pydantic
 from tokamax._src import pydantic as pydantic_lib
 from tokamax._src.ops.normalization import base
-from tokamax._src.ops.normalization import pallas_triton_config
+from tokamax._src.ops.normalization import triton_config
 
 
 @pydantic.dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
@@ -31,7 +31,7 @@ class Config:
   num_warps: pydantic_lib.PowerOfTwo
 
 
-Key = pallas_triton_config.Key
+Key = triton_config.Key
 
 
 def get_heuristics_config(
@@ -46,13 +46,13 @@ def get_heuristics_config(
   """Returns a config based on heuristics."""
   del residuals, out, dout  # Unused.
   # Re-use the forwards heuristics.
-  config = pallas_triton_config.get_heuristics_config(
+  config = triton_config.get_heuristics_config(
       x, scale, offset, block_size_per_warp=2048, **kwargs
   )
   return Config(**dataclasses.asdict(config))
 
 
-_canonicalize_shape = pallas_triton_config.canonicalize_shape
+_canonicalize_shape = triton_config.canonicalize_shape
 
 
 def _maybe_shape(x, axis) -> jax.ShapeDtypeStruct | None:


### PR DESCRIPTION
This PR ports the pallas_triton implementation normalization to raw triton, as pallas_triton will be deprecated. Currently, the added test only compares the jax_triton implementation to the pallas_triton one, and does not port replicate the full set of pallas_triton tests for jax_triton. 