### PR TITLE
Scale the Pallas-Triton attention VJP block sizes with the head dim.

### DIFF
--- a/tokamax/_src/ops/attention/pallas_triton_vjp.py
+++ b/tokamax/_src/ops/attention/pallas_triton_vjp.py
@@ -587,16 +587,32 @@ class PallasTritonFlashAttentionVjp(base.DotProductAttentionVjp[Config, None]):
 
   @override
   def _get_heuristics_config(self, ba: op.BoundArguments) -> Config:
-    # TODO: Implement heuristics.
+    # TODO: Tune these for performance. They are currently only sized to fit in
+    # shared memory, and do not take the sequence length or the device into
+    # account the way the forward heuristics do.
+    *_, q, _, v = ba.args
+    head_dim = max(q.shape[-1], v.shape[-1])
+    row_bytes = pl.next_power_of_2(head_dim) * jnp.dtype(q.dtype).itemsize
+
+    # Shared memory usage scales with `block * head_dim`, and head dims are
+    # padded to a power of two. The blocks below fit a 512-byte row (head dim
+    # 256 in bf16); shrink them beyond that, otherwise the kernel exceeds the
+    # shared memory limit. All four are dot dimensions, so none goes below 16;
+    # `block_m1` and `block_n2` are halved again for the causal diagonal, so
+    # they stop at 32 to keep those halves at 16.
+    #
+    # Shrinking the blocks is enough on its own, and `num_stages` stays at 2.
+    # Lowering it does not buy shared memory back in bf16: the compiler asks for
+    # more with one stage than with two (201088 vs 229376 bytes at head dim 512,
+    # blocks 32/64/64/32).
+    shrink = max(1, pl.next_power_of_2(-(-row_bytes // 512)))
     return Config(
         block_m1=32,
-        block_n1=64,
-        block_m2=64,
-        # block_n1=128,
-        # block_m2=128,
+        block_n1=max(16, 64 // shrink),
+        block_m2=max(16, 64 // shrink),
         block_n2=32,
         num_warps=4,
-        num_stages=2,  # 5,
+        num_stages=2,
     )
 
   # TODO: Implement an autotuning search space.


### PR DESCRIPTION
Scale the Pallas-Triton attention VJP block sizes with the head dim.

`_get_heuristics_config` returned fixed block sizes, so shared memory usage grew with the head dim until the kernel no longer fit. On an A100 the default config fails to compile for head dim 320 and 512 in bf16, both with `RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 203136, available: 166912`, identically, because both pad to 512. It also fails for head dim 256 in fp32. The blocks now shrink once a padded row exceeds 512 bytes.

That threshold is where the previous values stop fitting, measured rather than guessed. Sweeping block configs against the compiler on an A100 gives a consistent boundary in both dtypes:

| bytes per padded row | default config |
| --- | --- |
| 512 (head dim 256 bf16) | fits |
| 1024 (head dim 512 bf16) | does not fit |
| 1024 (head dim 256 fp32) | does not fit |
| 2048 (head dim 1024 bf16, head dim 512 fp32) | does not fit at any block size |

Head dims that already fit are unaffected: at 512 bytes per row and below the config is unchanged, so there is no effect on existing shapes. Head dims 320 and 512 in bf16 now compile and match an unfused fp32 reference to 7.5e-3 on dq, dk and dv, and head dim 256 in fp32 compiles where it previously did not.

`num_stages` deliberately stays at 2. Shrinking the blocks is sufficient on its own, and lowering it does not buy shared memory back in bf16: the compiler asks for more with one stage than with two, for instance 229376 bytes versus 201088 at head dim 512 with blocks 32/64/64/32. No runtime comparison accompanies this: the only machine available to me is shared, and the same config varied by up to 8x between runs there.

Three things this does not address, in case you want them handled differently:

Rows of 2048 bytes and above still do not fit at any block size, which means head dim 1024 in bf16 and head dim 512 in fp32. The blocks are dot dimensions and cannot go below 16, and `block_m1` and `block_n2` are halved again for the causal diagonal, so the smallest config this kernel can express still wants 196608 bytes there. Reaching those shapes needs a change to the kernel itself, so the supported range is a padded row of 1024 bytes or less: head dim 512 in bf16, 256 in fp32.

The threshold is derived from the A100 limit and applied on every device. Deriving it from the device limit instead would need the allocation to be predictable from the config, and it is not: a formula that fits every bf16 measurement exactly is wrong for fp32, and the ordering between `num_stages` 1 and 2 inverts between the two dtypes. As it stands the threshold errs unsafe on sm86 and sm89, which have 99KB per block against the A100's 163KB, and conservative on sm90 and sm100, which have more. Refining it needs hardware I do not have.

This only touches the default config. Per-shape tuning remains the job of `_get_autotuning_configs`, which is unchanged.


