### PR TITLE
Fix slow mask processing for causal masks.

### DIFF
--- a/tokamax/_src/ops/experimental/tpu/splash_attention/ring_attention_kernel.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/ring_attention_kernel.py
@@ -662,6 +662,11 @@ def make_ring_attention(
   if config is None:
     config = SplashConfig.get_default()
 
+  if config.qk_diag_skip:
+    # The ring masks are arbitrary NumpyMasks, so the skip cannot assume that
+    # kv > q entries are masked.
+    raise ValueError("qk_diag_skip=True is not supported with ring attention.")
+
   process_fn = partial(
       mask_info_lib.process_mask,
       downcast_smem_data=downcast_smem_data,

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/ring_attention_kernel_test.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/ring_attention_kernel_test.py
@@ -172,5 +172,22 @@ class RingAttentionTest(test_utils.SplashAttentionTestCase):
       self._assert_allclose(dv, dv_ref, rtol=1e-2, atol=1e-2)
 
 
+class RingAttentionValidationTest(test_utils.SplashAttentionTestCase):
+
+  def test_qk_diag_skip_rejected(self):
+    block = 256
+    config = splash.SplashConfig(
+        block_q=block, block_kv=block, block_kv_compute=block,
+        block_q_dkv=block, block_kv_dkv=block, block_kv_dkv_compute=block,
+        use_fused_bwd_kernel=True, residual_checkpoint_name="context",
+        qk_diag_skip=True,
+    )
+    mask = mask_lib.NumpyMask(mask_lib.make_causal_mask((512, 512)))
+    with self.assertRaisesRegex(ValueError, "ring attention"):
+      ring_attention_kernel.make_ring_attention(
+          mask, is_mqa=False, ring_axis="ring", config=config
+      )
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel.py
@@ -2186,16 +2186,26 @@ def _make_splash_attention(
   if config is None:
     config = SplashConfig.get_default()
 
-  if config.qk_diag_skip and not isinstance(mask, mask_lib.CausalMask):
-    # The skip assumes kv > q is ALWAYS masked — a pure-causal property. Any mask
-    # that admits a valid kv > q entry (bidirectional, local/sliding window, custom)
-    # would be silently corrupted, so fail loud. (Square-block preconditions are
-    # enforced in SplashConfig.__post_init__.)
-    raise ValueError(
-        "qk_diag_skip=True requires a pure CausalMask (the skip fills mask_value "
-        "for all kv > q sub-tiles, assuming the mask masks exactly those); got "
-        f"{type(mask).__name__}. Disable qk_diag_skip for non-causal masks."
-    )
+  if config.qk_diag_skip:
+    if not isinstance(mask, mask_lib.CausalMask):
+      # The skip assumes kv > q is ALWAYS masked — a pure-causal property. Any mask
+      # that admits a valid kv > q entry (bidirectional, local/sliding window, custom)
+      # would be silently corrupted, so fail loud. (Square-block preconditions are
+      # enforced in SplashConfig.__post_init__.)
+      raise ValueError(
+          "qk_diag_skip=True requires a pure CausalMask (the skip fills mask_value "
+          "for all kv > q sub-tiles, assuming the mask masks exactly those); got "
+          f"{type(mask).__name__}. Disable qk_diag_skip for non-causal masks."
+      )
+    if mask.offset != 0 or not np.array_equal(
+        mask.q_sequence, np.arange(mask.shape[0], dtype=np.int32)
+    ):
+      # A shifted or permuted causal boundary no longer lies on the physical
+      # diagonal, so the skipped sub-tiles can contain valid entries.
+      raise ValueError(
+          "qk_diag_skip=True requires offset=0 and an unpermuted q_sequence; "
+          "disable it for shifted or permuted causal masks."
+      )
 
   process_fn = partial(
       mask_info_lib.process_mask,
@@ -2266,6 +2276,11 @@ def _make_dynamic_splash_attention(
 
   if config is None:
     config = SplashConfig.get_default()
+
+  if config.qk_diag_skip:
+    # A dynamic mask is an arbitrary array, so the skip cannot assume that
+    # kv > q entries are masked.
+    raise ValueError("qk_diag_skip=True is not supported with dynamic masks.")
 
   # This is the only mode that supports the dynamic grid.
   config = dataclasses.replace(config, dq_reduction_steps=3)

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel_test.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_kernel_test.py
@@ -737,6 +737,19 @@ class SplashAttentionTest(test_utils.SplashAttentionTestCase):
     )
     with self.assertRaisesRegex(ValueError, "CausalMask"):
       splash.make_splash_mha_single_device(local, config=config)
+    # Permuted q_sequence -> raises (the causal boundary leaves the diagonal).
+    permuted = mask_lib.CausalMask(shape=(seq_len, seq_len))
+    permuted.q_sequence = permuted.q_sequence[::-1].copy()
+    with self.assertRaisesRegex(ValueError, "unpermuted q_sequence"):
+      splash.make_splash_mha_single_device(permuted, config=config)
+    # Nonzero offset -> raises for the same reason.
+    shifted = mask_lib.CausalMask(shape=(seq_len, seq_len), offset=5)
+    with self.assertRaisesRegex(ValueError, "offset=0"):
+      splash.make_splash_mha_single_device(shifted, config=config)
+    # Dynamic mask -> raises (an arbitrary mask gives no causal guarantee).
+    dynamic = jnp.ones((seq_len, seq_len), dtype=jnp.bool_)
+    with self.assertRaisesRegex(ValueError, "dynamic masks"):
+      splash.make_dynamic_splash_mha(dynamic, config=config)
 
 
 if __name__ == "__main__":

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_mask_info.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_mask_info.py
@@ -350,6 +350,42 @@ def _process_dynamic_mask(
   )
 
 
+def _causal_state_grid(
+    mask: mask_lib.CausalMask,
+    q_block_size: int,
+    kv_block_size: int,
+) -> np.ndarray:
+  """Compute the block states of a causal mask without materializing it.
+
+  A block is empty if its highest Q position is below its lowest KV position,
+  full if its lowest Q position is at or above its highest KV position, and
+  partial otherwise. This holds for any permutation of the Q sequence.
+
+  Args:
+    mask: Causal mask to process.
+    q_block_size: Q block size of the Pallas grid.
+    kv_block_size: KV block size of the Pallas grid.
+
+  Returns:
+    An i32[q_blocks, kv_blocks] grid of block states: 0 = Empty, 1 = Partial,
+    2 = Full.
+  """
+  q_seq_len, kv_seq_len = mask.shape
+  q_sequence = mask.q_sequence.reshape(q_seq_len // q_block_size, q_block_size)
+  q_block_min = q_sequence.min(axis=1) + mask.offset
+  q_block_max = q_sequence.max(axis=1) + mask.offset
+
+  kv_block_min = (
+      np.arange(kv_seq_len // kv_block_size, dtype=np.int32) * kv_block_size
+  )
+  kv_block_max = kv_block_min + kv_block_size - 1
+
+  state_grid = np.ones((len(q_block_min), len(kv_block_min)), dtype=np.int32)
+  state_grid[q_block_max[:, None] < kv_block_min[None, :]] = 0
+  state_grid[q_block_min[:, None] >= kv_block_max[None, :]] = 2
+  return state_grid
+
+
 # When used in a transformer network with multiple layers, the SplashAttention
 # kernel is created several times with the same mask. Cache MaskInfo to avoid
 # blowing up compile times. Ideally the size of the cache should be determined
@@ -441,31 +477,36 @@ def _process_mask(
   # blocks are replicated across shards.
 
   blocked_shape = (q_blocks_count, kv_blocks_count)
-  state_grid = np.zeros(blocked_shape, dtype=np.int32)
   partial_id_grid = np.full(blocked_shape, -1, dtype=np.int32)
 
   partial_blocks_map = collections.defaultdict(lambda: len(partial_blocks_map))
   unique_chunks = []
 
-  # Partition the dense mask into blocks and categorize them:
-  # 0 = Empty, 1 = Partial (mixed 0s and 1s), 2 = Full (all 1s).
-  # Partial blocks are deduplicated and stored in unique_chunks to save memory.
-  for coords in np.ndindex((q_blocks_count, kv_blocks_count)):
-    (q_idx, kv_idx) = coords
-    chunk = mask[(
-        slice(q_idx * q_block_size, (q_idx + 1) * q_block_size),
-        slice(kv_idx * kv_block_size, (kv_idx + 1) * kv_block_size),
-    )]
-    if chunk.any():
-      if chunk.all():
-        state_grid[q_idx, kv_idx] = 2
-      else:
-        state_grid[q_idx, kv_idx] = 1
-        chunk_id = partial_blocks_map[_HashableNDArray(chunk)]
-        partial_id_grid[q_idx, kv_idx] = chunk_id
+  if isinstance(mask, mask_lib.CausalMask):
+    # Causal block states follow from the Q positions alone, and the
+    # mask_function computes the partial blocks inside the kernel.
+    state_grid = _causal_state_grid(mask, q_block_size, kv_block_size)
+  else:
+    state_grid = np.zeros(blocked_shape, dtype=np.int32)
+    # Partition the dense mask into blocks and categorize them:
+    # 0 = Empty, 1 = Partial (mixed 0s and 1s), 2 = Full (all 1s).
+    # Partial blocks are deduplicated and stored in unique_chunks to save memory.
+    for coords in np.ndindex((q_blocks_count, kv_blocks_count)):
+      (q_idx, kv_idx) = coords
+      chunk = mask[(
+          slice(q_idx * q_block_size, (q_idx + 1) * q_block_size),
+          slice(kv_idx * kv_block_size, (kv_idx + 1) * kv_block_size),
+      )]
+      if chunk.any():
+        if chunk.all():
+          state_grid[q_idx, kv_idx] = 2
+        else:
+          state_grid[q_idx, kv_idx] = 1
+          chunk_id = partial_blocks_map[_HashableNDArray(chunk)]
+          partial_id_grid[q_idx, kv_idx] = chunk_id
 
-        if chunk_id == len(unique_chunks):
-          unique_chunks.append(chunk)
+          if chunk_id == len(unique_chunks):
+            unique_chunks.append(chunk)
 
   full_mask = (state_grid == 2).all()
   if full_mask:

--- a/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_mask_test.py
+++ b/tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_mask_test.py
@@ -1071,6 +1071,47 @@ class SplashAttentionMaskInfoTest(test_utils.SplashAttentionTestCase):
     self._assert_mask_info_match(mask_info, expected_mask_info)
     self._assert_mask_info_match(mask_info_dkv, expected_mask_info_dkv)
 
+  def test_causal_mask_with_permuted_q_sequence(self):
+    sequence_lengths = (64, 64)
+    block_shape = (16, 16)
+
+    causal_mask = mask_lib.CausalMask(sequence_lengths)
+    # Load balanced ordering: rank r of 2 holds chunks r and 3 - r of 4.
+    chunks = np.split(np.arange(sequence_lengths[0], dtype=np.int32), 4)
+    causal_mask.q_sequence = np.concatenate(
+        [chunks[0], chunks[3], chunks[1], chunks[2]]
+    )
+
+    mask_info, mask_info_dkv, mask_function = self._process_mask(
+        causal_mask, block_shape
+    )
+    self.assertIsNotNone(mask_function)
+
+    expected_num_active_blocks = np.array([10], dtype=np.int32)
+
+    expected_mask_info = mask_info_lib.MaskInfo(
+        None,
+        np.array([0, 1, 1, 1, 1, 2, 2, 3, 3, 3], dtype=np.int8),
+        np.array([0, 0, 1, 2, 3, 0, 1, 0, 1, 2], dtype=np.int8),
+        np.array([1, 2, 2, 2, 1, 2, 1, 2, 2, 1], dtype=np.int8),
+        expected_num_active_blocks,
+        None,
+        causal_mask.q_sequence,
+    )
+
+    expected_mask_info_dkv = mask_info_lib.MaskInfo(
+        None,
+        np.array([0, 0, 0, 0, 1, 1, 1, 2, 2, 3], dtype=np.int8),
+        np.array([0, 1, 2, 3, 1, 2, 3, 1, 3, 1], dtype=np.int8),
+        np.array([1, 2, 2, 2, 2, 1, 2, 2, 1, 1], dtype=np.int8),
+        expected_num_active_blocks,
+        None,
+        causal_mask.q_sequence,
+    )
+
+    self._assert_mask_info_match(mask_info, expected_mask_info)
+    self._assert_mask_info_match(mask_info_dkv, expected_mask_info_dkv)
+
   @parameterized.parameters((True,), (False,))
   def test_local_mask(self, is_lazy_mask: bool):
     sequence_lengths = (64, 64)


### PR DESCRIPTION
# Description

Currently _process_mask builds every mask block in a Python loop to classify it as empty/partial/full. This is quadratic in sequence length eg ~13 min for a 1M causal mask

This PR proposes skipping the loop for causal masks. Also works for permuted q_sequence (load balanced CP). 

### Performance comparison

`process_mask` wall time for a causal mask with a permuted `q_sequence`, block shape (512, 512)

| Sequence length | Before | After |
|---|---|---|
| 64K | 3.0 s | 0.001 s |
| 128K | 14.5 s | 0.001 s |
| 256K | 47.4 s | 0.004 s |
| 1M | 755 s | 0.067 s |

# Test
`pytest tokamax/_src/ops/experimental/tpu/splash_attention/splash_attention_mask_test.py ring_attention_kernel_test.py`

```
splash_attention_mask_test.py::SplashAttentionMaskInfoTest::test_causal_mask_with_permuted_q_sequence PASSED
splash_attention_mask_test.py::SplashAttentionMaskInfoTest::test_rectangular_wide_causal_mask0 PASSED
splash_attention_mask_test.py::SplashAttentionMaskInfoTest::test_rectangular_tall_causal_mask0 PASSED
splash_attention_mask_test.py::SplashAttentionMaskInfoTest::test_causal_two_q_shards_two_kv_shards0 PASSED
ring_attention_kernel_test.py::RingAttentionValidationTest::test_qk_diag_skip_rejected PASSED
...
25 passed, 119 skipped