### PR TITLE
calculate_tiling: derive tile_m's target from the hardware instead of hardcoding 128

### DIFF
--- a/tokamax/_src/ops/experimental/gmm_v2/gmm_v2.py
+++ b/tokamax/_src/ops/experimental/gmm_v2/gmm_v2.py
@@ -978,13 +978,20 @@ def calculate_tiling(
   lhs_bits = jax.dtypes.itemsize_bits(lhs_dtype)
   rhs_bits = jax.dtypes.itemsize_bits(rhs_dtype)
 
-  # When using bf16 for lhs and rhs, 128 is the largest tile_m value that is
-  # safe to use for most scenarios. But if lower bitwidth is used, we need
-  # to tweak tile_m to account for using faster hardware unit.
-  # TODO: Account for different TPU hardware specs.
-  bf16_bf16_tile_m = 128
+  # tile_m targets the MXU's row granularity, read from the hardware rather than hardcoded. This
+  # discharges the "# TODO: Account for different TPU hardware specs." that sat here; tile_n_limit
+  # below already derives itself from mxu_column_size.
+  mxu_tile_m = pltpu.get_tpu_info().mxu_column_size
   rhs_mod = min(pl.cdiv(16, rhs_bits), 2)
-  tile_m = bf16_bf16_tile_m // rhs_mod
+
+  # Floored at the value this function returned before, so no shape and no generation gets a
+  # smaller tile_m than before. Capped at twice the mean rows per group, because fill_metadata
+  # emits ceil(group_size / tile_m) tiles per group, so the last tile of every group is partially
+  # filled and the padding grows with tile_m. A tile_m sweep on v5p / v6e / v7x sets both bounds
+  # and rules out going higher -- see the commit message for the measurements.
+  legacy_tile_m = 128 // rhs_mod
+  mean_rows_per_group = dims.size_m // max(dims.size_group, 1)
+  tile_m = min(mxu_tile_m // rhs_mod, max(legacy_tile_m, 2 * mean_rows_per_group))
   if lhs_cfgs.should_quantize:
     tile_m *= 2
   tile_m = min(tile_m, dims.size_m)


### PR DESCRIPTION
`tile_m` is the only tile dimension here with no hardware input. `tile_n_limit` below already derives itself from `mxu_column_size`; `tile_m` carries a literal `128` and a `# TODO: Account for different TPU hardware specs.`

| part | `get_tpu_info().mxu_column_size` |
|---|---:|
| v5p | 128 |
| v6e | 256 |
| v7x | 256 |

Bounded below by the previous return value, so nothing gets a smaller `tile_m` than today, and above by `2 ×` the mean rows per group, since `fill_metadata` emits `ceil(group_size / tile_m)` tiles per group and padding grows with `tile_m`.

Speedup of `tile_m` 128 → 256. One chip, bf16, median of 20, six shapes × three group-size distributions (balanced; ±50% skew; every group one tile over). Balanced column shown:

| shape | v7x | v6e | v5p |
|---|---:|---:|---:|
| `m=65536 g=128 k=3072 n=2048` | 1.31× | 1.30× | 1.02× |
| `m=65536 g=128 k=2048 n=3072` | 1.36× | 1.27× | 1.02× |
| `m=262144 g=256 k=7168 n=1024` | 1.22× | 1.06× | 1.02× |
| `m=65536 g=128 k=3072 n=512` | 1.59× | 1.29× | 1.05× |
| `m=16384 g=128` (mean 128/group) | 1.00× | 1.00× | **0.56×** |
| `m=65536 g=512` (mean 128/group) | 1.01× | 1.11× | **0.53×** |
| **cells ≥ 1.00× over all 3 distributions** | **18/18** | **16/18** | **8/18** |

v6e tracks v7x; its two misses are 0.997× and 0.995×. v5p regresses ten cells, 21–47% on both mean-128 shapes. `mxu_column_size` is the `min`, so v5p keeps 128 — hardcoding 256 instead would have shipped that regression.

`tile_m=512` is ~4% faster balanced and 25–40% slower ragged on v7x/v5p, and over VMEM at the larger shapes (the f32 accumulator alone is 50.3 MB of a 57.6 MB limit). v6e has 128 MiB and prefers 512, but a static 512 regresses the other two.

`num_k` is unchanged, so bit-exact; bf16 matches an f32 `ragged_dot` reference to `rel 2.25e-03` at every `tile_m` on all three parts.
