### PR TITLE
Remove typeguard pin: use pydantic as the jaxtyping runtime typechecker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "pydantic>=2.11.0",
     "qwix>=0.1.2",
     "tqdm",
-    "typeguard==2.13.3",
     "immutabledict",
     "tensorboardx",
     "xprof>=2.23.1",

--- a/tokamax/_src/jaxtyping.py
+++ b/tokamax/_src/jaxtyping.py
@@ -19,11 +19,20 @@ import jax.numpy as jnp
 import jaxtyping
 from jaxtyping import Array, Int  # pylint: disable=g-importing-member,g-multiple-import
 import numpy as np
-import typeguard
+import pydantic
 
 
 ScalarInt = Int[Array, ""] | Int[np.generic, ""] | Int[jnp.generic, ""]
-jaxtyped = jaxtyping.jaxtyped(typechecker=typeguard.typechecked)
+# pydantic (already a dependency) is used as the runtime typechecker rather
+# than typeguard: typeguard>=3 is incompatible with jaxtyping (its AST
+# instrumentation parses shape strings like "A B" as forward references), and
+# pinning typeguard==2.13.3 conflicts with packages requiring typeguard>=4
+# (see https://github.com/openxla/tokamax/issues/240).
+_typechecker = pydantic.validate_call(
+    config=pydantic.ConfigDict(arbitrary_types_allowed=True),
+    validate_return=True,
+)
+jaxtyped = jaxtyping.jaxtyped(typechecker=_typechecker)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes #240.

## Problem

As reported in #240 ([Fixed typeguard version prevents installation](https://github.com/openxla/tokamax/issues/240)):

> I have tried to install `tokamax` in the same environment as `tyro` (which requires `typeguard>=4.0.0`), which consequently fails. I think fixing the version instead of providing a lower bound is an anti-pattern. Maybe you can reconsider the `typeguard` version or make runtime type checking optional.
>
> As you use `pydantic` already you might consider using it for the runtime type checking as well.

This blocks installing tokamax alongside anything that depends on tyro (e.g. torchtitan) because pip cannot satisfy `typeguard==2.13.3` and `typeguard>=4.0.0` in one environment.

## Why the pin cannot simply be relaxed

The pin is not accidental. `typeguard>=3` instruments functions via AST rewriting and treats string annotations as forward references, so it tries to `ast.parse()` jaxtyping shape strings and fails at decoration time:

```
File "typeguard/_transformer.py", line 471, in visit_Constant
    expression = ast.parse(node.value, mode="eval")
File "<unknown>", line 1
    A C
      ^
SyntaxError: invalid syntax
```

jaxtyping officially supports only `typeguard==2.13.3` or `beartype` as typecheckers, so the checker itself has to change, not the version bound.

## Fix

This PR implements the third option suggested in the issue: use pydantic (already a tokamax dependency, `pydantic>=2.11.0`) as the jaxtyping runtime typechecker, and drop typeguard from the dependency tree entirely. This is the pattern proposed in [patrick-kidger/jaxtyping#354](https://github.com/patrick-kidger/jaxtyping/issues/354).

```python
_typechecker = pydantic.validate_call(
    config=pydantic.ConfigDict(arbitrary_types_allowed=True),
    validate_return=True,
)
jaxtyped = jaxtyping.jaxtyped(typechecker=_typechecker)
```

The public error contract is unchanged: jaxtyping catches any exception raised by the typechecker and re-raises its own `jaxtyping.TypeCheckError`, so callers and tests see the same exception type as before. `validate_return=True` preserves return-type checking (without it, return annotations are silently unchecked). The array shape/dtype checks are unaffected — they are performed by jaxtyping itself via `isinstance`, regardless of which typechecker is plugged in.

## Verification

All on jaxtyping 0.3.11, pydantic 2.12.4, CPU, at current `main`:

| Check | typeguard 2.13.3 (before) | pydantic (after) |
|---|---|---|
| valid call passes | OK | OK |
| rank mismatch -> `jaxtyping.TypeCheckError` | OK | OK |
| cross-argument dim consistency (shared `"B"`) | OK | OK |
| bad return type | OK | OK |
| dtype mismatch (`int32` where `Float`) | OK | OK |
| `disable_jaxtyping()` context manager | OK | OK |
| full `import tokamax` (all `@jaxtyped` modules decorate) | OK | OK |
| `gated_linear_unit` / `linear_softmax_cross_entropy_loss` real calls | OK | OK |

Test suite (CPU-safe subset): `jaxtyping_test.py`, `pydantic_test.py`, `shape_test.py`, `batching_test.py`, `config_test.py`, `precision_test.py`, `ad_test.py` — **154 passed, 18 skipped, 0 failed**.

Coexistence with the modern typeguard that tyro needs: with `typeguard 4.6.0` installed in the same environment, `import tokamax` and op execution work correctly (previously this failed at import).

## Behavioral notes

- Pydantic validates non-array Python parameters by coercion in its default mode, so it is slightly more lenient than typeguard's strict `isinstance` on scalar annotations (e.g. an `int` passed where `float` is annotated is now accepted). jaxtyping calls the original function with the original arguments, so no values are ever converted — only acceptance is marginally laxer, and only for non-array annotations.
- typeguard 2.x was a no-op under `PYTHONOPTIMIZE`/`-O`; pydantic's `validate_call` stays active. The existing `disable_jaxtyping()` / `jaxtyping.config` switch remains the supported way to disable runtime checking.
