### PR TITLE
Expose the build's git revision as tokamax.__git_revision__

### DIFF
--- a/tokamax/__init__.py
+++ b/tokamax/__init__.py
@@ -37,6 +37,7 @@ from tokamax._src.ops.ragged_dot.api import ragged_dot_general as ragged_dot_gen
 from tokamax._src.ops.ragged_dot.base import generate_group_sizes as generate_ragged_dot_group_sizes
 from tokamax._src.ops.ragged_dot.base import GroupSizes as RaggedDotGroupSizes
 from tokamax._src.ops.triangle_multiplication.api import triangle_multiplication as triangle_multiplication
+from tokamax._src.version import TOKAMAX_GIT_REVISION as __git_revision__
 from tokamax._src.version import TOKAMAX_VERSION as __version__
 from tokamax._src.version import TOKAMAX_VERSION_INFO as __version_info__
 

--- a/tokamax/_src/version.py
+++ b/tokamax/_src/version.py
@@ -19,6 +19,9 @@ from typing import Final
 
 TOKAMAX_VERSION: Final[str] = "0.0.13"
 
+# Stamped at build time by the release workflow; empty in a source checkout.
+TOKAMAX_GIT_REVISION: Final[str] = ""
+
 
 def _version_as_tuple(version_str: str) -> tuple[int, int, int]:
   x, y, z = (int(i) for i in version_str.split(".") if i.isdigit())


### PR DESCRIPTION
## What

Adds `TOKAMAX_GIT_REVISION` to `tokamax/_src/version.py` — empty in a source checkout, stamped by the release workflow at build time — and re-exports it as `tokamax.__git_revision__` alongside `__version__`.

## Why

We're setting up nightly `.devN` wheels for tokamax so downstream projects (tpu-inference) can track kernel changes without pinning a git SHA, which PyPI rejects in wheel metadata (`400 Can't have direct dependency`).

That leaves no way to map a published nightly back to a commit. PyPI also rejects PEP 440 local version identifiers, so the SHA can't ride along in the version string — `0.0.14.dev20260828+gabc1234` is not uploadable, and a date alone is ambiguous when several commits land in a day.

A constant in the wheel solves it. Consumers can then confirm a pinned nightly actually contains an intended change, and bisect a regression back to a tokamax commit.

## Notes

- No behavior change: the constant is empty until a follow-up PR adds the stamping step to `publish.yml`.
- Kept as a plain constant rather than shelling out to `git`, since it must work from an installed wheel where there is no repo.
- `_version_as_tuple` is unaffected — verified that a stamped `0.0.14.dev20260828` still parses to `(0, 0, 14)`, since `isdigit()` filters the `dev*` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsaExgFXpwo7zzWWncRzZq