### PR TITLE
Expose the build's git revision as tokamax.__git_revision__

### DIFF
--- a/tokamax/__init__.py
+++ b/tokamax/__init__.py
@@ -37,6 +37,7 @@ from tokamax._src.ops.ragged_dot.api import ragged_dot_general as ragged_dot_gen
 from tokamax._src.ops.ragged_dot.base import generate_group_sizes as generate_ragged_dot_group_sizes
 from tokamax._src.ops.ragged_dot.base import GroupSizes as RaggedDotGroupSizes
 from tokamax._src.ops.triangle_multiplication.api import triangle_multiplication as triangle_multiplication
+from tokamax._src.version import TOKAMAX_GIT_REVISION as __git_revision__
 from tokamax._src.version import TOKAMAX_VERSION as __version__
 from tokamax._src.version import TOKAMAX_VERSION_INFO as __version_info__
 

--- a/tokamax/_src/version.py
+++ b/tokamax/_src/version.py
@@ -19,6 +19,9 @@ from typing import Final
 
 TOKAMAX_VERSION: Final[str] = "0.0.13"
 
+# Stamped at build time by the release workflow; empty in a source checkout.
+TOKAMAX_GIT_REVISION: Final[str] = ""
+
 
 def _version_as_tuple(version_str: str) -> tuple[int, int, int]:
   x, y, z = (int(i) for i in version_str.split(".") if i.isdigit())


### PR DESCRIPTION
Adds a TOKAMAX_GIT_REVISION constant, empty in a source checkout and stamped by the release workflow at build time, plus a re-export as `tokamax.__git_revision__` alongside __version__.

Exposing it as a constant lets a published wheel be mapped back to the exact commit it was built from, which downstream consumers need to confirm a pinned nightly contains an intended change and to bisect a regression back to a tokamax commit.

The value exists to identify published artifacts, where the wheel is the only artifact you have. In a source checkout you already have the answer: git rev-parse HEAD in the clone itself.

Verification: With this change, after we install a tokamax wheel, we should be able to do `python -c "import tokamax; print(tokamax.__git_revision__)"` and get an expected commit (the nightly CI tested commit which will be also checked in the `.github/workflows/publish.yml`).