### PR TITLE
Fix undefined function references in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ out = f_grad(x, scale)
 To get the best performance, autotune all Tokamax kernels in `f_grad`:
 
 ```python
-autotune_result: tokamax.AutotuningResult = tokamax.autotune(f, x, scale)
+autotune_result: tokamax.AutotuningResult = tokamax.autotune(f_grad, x, scale)
 ```
 
 `autotune_result` can be used as a context-manager, using the autotuned configs
@@ -166,7 +166,7 @@ execution time. This means the usual approach of timing
 for only measuring accelerator execution time:
 
 ```python
-f_std, args = tokamax.standardize_function(f, kwargs={'x': x, 'scale': scale})
+f_std, args = tokamax.standardize_function(f_grad, kwargs={'x': x, 'scale': scale})
 bench: tokamax.BenchmarkData = tokamax.benchmark(f_std, args)
 ```
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -49,7 +49,7 @@ out = f_grad(x, scale)
 To get the best performance, autotune all Tokamax kernels in `f_grad`:
 
 ```python
-autotune_result: tokamax.AutotuningResult = tokamax.autotune(f, x, scale)
+autotune_result: tokamax.AutotuningResult = tokamax.autotune(f_grad, x, scale)
 ```
 
 `autotune_result` can be used as a context-manager, using the autotuned configs
@@ -112,7 +112,7 @@ for only measuring accelerator execution time:
 
 ```python
 
-f_std, args = tokamax.benchmarking.standardize_function(f, kwargs={'x': x, 'scale': scale})
+f_std, args = tokamax.benchmarking.standardize_function(f_grad, kwargs={'x': x, 'scale': scale})
 run = tokamax.benchmarking.compile_benchmark(f_std, args)
 bench: tokamax.benchmarking.BenchmarkData = run(args)
 ```


### PR DESCRIPTION
The examples define the compiled gradient as f_grad but pass an undefined f to the autotuning and benchmarking APIs. Use f_grad consistently in both copies of the usage documentation.

The reference became stale when #114 updated the example to use the callable API and the benchmarking reference was introduced in #751. 